### PR TITLE
Pre-Loaded Responses

### DIFF
--- a/typeform/src/androidMain/kotlin/com/typeform/ui/fields/StatementView.kt
+++ b/typeform/src/androidMain/kotlin/com/typeform/ui/fields/StatementView.kt
@@ -6,7 +6,6 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
 import com.typeform.schema.Statement
-import com.typeform.schema.Validations
 import com.typeform.ui.components.StyledTextView
 import com.typeform.ui.models.Settings
 
@@ -14,22 +13,7 @@ import com.typeform.ui.models.Settings
 internal fun StatementView(
     settings: Settings,
     properties: Statement,
-    validations: Validations?,
-    validationHandler: ((Boolean) -> Unit)?,
 ) {
-    fun determineValidity() {
-        if (validationHandler == null) {
-            return
-        }
-
-        if (validations == null || !validations.required) {
-            validationHandler(true)
-            return
-        }
-
-        validationHandler(true)
-    }
-
     Column(
         verticalArrangement = Arrangement.spacedBy(settings.presentation.descriptionContentVerticalSpacing),
     ) {
@@ -40,8 +24,6 @@ internal fun StatementView(
             )
         }
     }
-
-    determineValidity()
 }
 
 @Preview(showBackground = true, showSystemUi = true)
@@ -54,7 +36,5 @@ private fun StatementViewPreview() {
             button_text = "Continue",
             description = null,
         ),
-        validations = null,
-        validationHandler = null,
     )
 }

--- a/typeform/src/androidMain/kotlin/com/typeform/ui/models/NavigationAction.kt
+++ b/typeform/src/androidMain/kotlin/com/typeform/ui/models/NavigationAction.kt
@@ -5,5 +5,5 @@ import com.typeform.models.Position
 sealed class NavigationAction {
     data class PositionAction(val position: Position) : NavigationAction()
     data class ConclusionAction(val conclusion: Conclusion) : NavigationAction()
-    object Back : NavigationAction()
+    data object Back : NavigationAction()
 }

--- a/typeform/src/androidMain/kotlin/com/typeform/ui/models/ResponseState.kt
+++ b/typeform/src/androidMain/kotlin/com/typeform/ui/models/ResponseState.kt
@@ -1,0 +1,18 @@
+package com.typeform.ui.models
+
+import com.typeform.models.ResponseValue
+import com.typeform.models.Responses
+import com.typeform.schema.Field
+
+data class ResponseState(
+    val response: ResponseValue? = null,
+    val invalid: Boolean = true,
+) {
+    constructor(
+        field: Field,
+        responses: Responses
+    ): this(
+        response = responses[field.ref],
+        invalid = field.properties.asStatement() == null
+    )
+}

--- a/typeform/src/androidMain/kotlin/com/typeform/ui/preview/FormPreview.kt
+++ b/typeform/src/androidMain/kotlin/com/typeform/ui/preview/FormPreview.kt
@@ -4,8 +4,10 @@ import com.typeform.schema.Field
 import com.typeform.schema.Form
 import com.typeform.schema.FormType
 import com.typeform.schema.Links
+import com.typeform.schema.ScreenProperties
 import com.typeform.schema.Settings
 import com.typeform.schema.Theme
+import com.typeform.schema.WelcomeScreen
 import com.typeform.schema.Workspace
 import java.net.URL
 
@@ -52,7 +54,20 @@ val Form.Companion.preview: Form
         workspace = Workspace(
             href = URL("https://www.typeform.com")
         ),
-        welcome_screens = emptyList(),
+        welcome_screens = listOf(
+            WelcomeScreen(
+                id = "welcome1",
+                ref = "welcome1",
+                title = "Example Welcome Screen",
+                attachment = null,
+                properties = ScreenProperties(
+                    button_mode = null,
+                    button_text = "Continue",
+                    share_icons = null,
+                    show_button = true,
+                )
+            )
+        ),
         thankyou_screens = emptyList(),
     )
 

--- a/typeform/src/androidMain/kotlin/com/typeform/ui/structure/RejectedView.kt
+++ b/typeform/src/androidMain/kotlin/com/typeform/ui/structure/RejectedView.kt
@@ -15,6 +15,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.typeform.models.Responses
+import com.typeform.ui.models.Conclusion
 import com.typeform.ui.models.Settings
 
 /**
@@ -24,13 +26,16 @@ import com.typeform.ui.models.Settings
 internal fun RejectedView(
     scaffoldPadding: PaddingValues,
     settings: Settings,
-    onClick: () -> Unit,
+    responses: Responses,
+    onClick: (Conclusion) -> Unit,
 ) {
     ScrollingContentView(
         scaffoldPadding = scaffoldPadding,
         settings = settings,
         title = "Finish",
-        onClick = onClick,
+        onClick = {
+            onClick(Conclusion.Rejected(responses))
+        },
     ) {
         Column(
             modifier = Modifier.padding(settings.presentation.contentPadding),
@@ -56,6 +61,7 @@ private fun RejectedViewPreview() {
     RejectedView(
         scaffoldPadding = PaddingValues(0.dp),
         settings = Settings(),
+        responses = mutableMapOf(),
         onClick = {},
     )
 }

--- a/typeform/src/androidUnitTest/kotlin/com/typeform/PreloadedResponsesTests.kt
+++ b/typeform/src/androidUnitTest/kotlin/com/typeform/PreloadedResponsesTests.kt
@@ -1,0 +1,182 @@
+package com.typeform
+
+import com.typeform.models.Position
+import com.typeform.models.ResponseValue
+import com.typeform.models.Responses
+import com.typeform.schema.Choice
+import com.typeform.schema.WelcomeScreen
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.test.fail
+
+class PreloadedResponsesTests: TypeformTestCase() {
+
+    override val jsonResource: String
+        get() = "MedicalIntake26.json"
+
+    @Test
+    fun testNotSkippingWelcomeEmptyResponses() {
+        val responses: Responses = mutableMapOf()
+        val position: Position
+        try {
+            position = form.firstPosition(skipWelcomeScreen = false, responses = responses)
+        } catch (_ :Exception) {
+            fail("Unexpected Exception")
+        }
+
+        when (position) {
+            is Position.ScreenPosition -> {
+                assertTrue(position.screen is WelcomeScreen)
+                assertEquals("NGCT4k03bG7W", position.screen.id)
+            }
+            is Position.FieldPosition -> {
+                fail("Unexpected Position")
+            }
+        }
+    }
+
+    @Test
+    fun testNotSkippingWelcomeFirstFieldResponses() {
+        val responses: Responses = mutableMapOf(
+            Pair(
+                "508ea9df-177c-4cda-8371-8f7cc1bc60a2",
+                ResponseValue.ChoiceValue(
+                    Choice(
+                        id = "eSMBTpzeqJYQ",
+                        ref = "65fd22c3-32ec-4c92-b194-5aef3a10fe60",
+                        label = "Alabama"
+                    )
+                )
+            )
+        )
+
+        val position: Position
+        try {
+            position = form.firstPosition(skipWelcomeScreen = false, responses = responses)
+        } catch (_ :Exception) {
+            fail("Unexpected Exception")
+        }
+
+        when (position) {
+            is Position.ScreenPosition -> {
+                assertTrue(position.screen is WelcomeScreen)
+                assertEquals("NGCT4k03bG7W", position.screen.id)
+            }
+            is Position.FieldPosition -> {
+                fail("Unexpected Position")
+            }
+        }
+    }
+
+    @Test
+    fun testSkippingWelcomeEmptyResponses() {
+        val responses: Responses = mutableMapOf()
+
+        val position: Position
+        try {
+            position = form.firstPosition(skipWelcomeScreen = true, responses = responses)
+        } catch (_ :Exception) {
+            fail("Unexpected Exception")
+        }
+
+        when (position) {
+            is Position.ScreenPosition -> {
+                fail("Unexpected Position")
+            }
+            is Position.FieldPosition -> {
+                assertEquals("89Ofk9JaI4M1", position.field.id)
+            }
+        }
+    }
+
+    @Test
+    fun testSkippingWelcomeFirstFieldResponses() {
+        val responses: Responses = mutableMapOf(
+            Pair(
+                "508ea9df-177c-4cda-8371-8f7cc1bc60a2",
+                ResponseValue.ChoiceValue(
+                    Choice(
+                        id = "Rh7fHLNn7tRV",
+                        ref = "aa028c7c-ce34-428f-8563-35bce5201dc1",
+                        label = "Minnesota"
+                    )
+                )
+            )
+        )
+
+        val position: Position
+        try {
+            position = form.firstPosition(skipWelcomeScreen = true, responses = responses)
+        } catch (_ :Exception) {
+            fail("Unexpected Exception")
+        }
+
+        when (position) {
+            is Position.ScreenPosition -> {
+                fail("Unexpected Position")
+            }
+            is Position.FieldPosition -> {
+                assertEquals("0mMHJCj4JoPr", position.field.id)
+            }
+        }
+    }
+
+    // There is a 'Statement' field after the first response, and before the second response.
+    @Test
+    fun testSkippingWelcomePostStatementResponses() {
+        val responses: Responses = mutableMapOf(
+            Pair(
+                "508ea9df-177c-4cda-8371-8f7cc1bc60a2",
+                ResponseValue.ChoiceValue(
+                    Choice(
+                        id = "Rh7fHLNn7tRV",
+                        ref = "aa028c7c-ce34-428f-8563-35bce5201dc1",
+                        label = "Minnesota"
+                    )
+                )
+            ),
+            Pair(
+                "4915db69-55ca-4a00-b57e-893d7ea3e761",
+                ResponseValue.ChoiceValue(
+                    Choice(
+                        id = "QQP6V2LnuOBK",
+                        ref = "a66c1065-4e4f-46fc-8a26-794cc46a59f9",
+                        label = "Adult, 18-64 years of age"
+                    )
+                )
+            )
+        )
+
+        var position: Position
+        try {
+            position = form.firstPosition(skipWelcomeScreen = true, responses = responses)
+        } catch (_ :Exception) {
+            fail("Unexpected Exception")
+        }
+
+        when (position) {
+            is Position.ScreenPosition -> {
+                fail("Unexpected Position")
+            }
+            is Position.FieldPosition -> {
+                assertEquals("0mMHJCj4JoPr", position.field.id)
+            }
+        }
+
+        try {
+            position = form.nextPosition(from = position, responses = responses)
+        } catch (_ :Exception) {
+            fail("Unexpected Exception")
+        }
+
+        when (position) {
+            is Position.ScreenPosition -> {
+                fail("Unexpected Position")
+            }
+            is Position.FieldPosition -> {
+                assertEquals("0QSfTuGGV8W5", position.field.id)
+            }
+        }
+    }
+}

--- a/typeform/src/androidUnitTest/resources/MedicalIntake26.json
+++ b/typeform/src/androidUnitTest/resources/MedicalIntake26.json
@@ -1,0 +1,9353 @@
+{
+  "id": "qLnHVjxj",
+  "type": "quiz",
+  "title": "Async25",
+  "workspace": {
+    "href": "https://api.typeform.com/workspaces/jKFBYs"
+  },
+  "theme": {
+    "href": "https://api.typeform.com/themes/qQpgDt"
+  },
+  "settings": {
+    "language": "en",
+    "progress_bar": "percentage",
+    "meta": {
+      "allow_indexing": false
+    },
+    "hide_navigation": false,
+    "is_public": true,
+    "is_trial": false,
+    "show_progress_bar": true,
+    "show_typeform_branding": false,
+    "are_uploads_public": false,
+    "show_time_to_complete": true,
+    "show_number_of_submissions": false,
+    "show_cookie_consent": false,
+    "show_question_number": true,
+    "show_key_hint_on_choices": true,
+    "autosave_progress": true,
+    "free_form_navigation": false,
+    "pro_subdomain_enabled": false,
+    "capabilities": {
+      "e2e_encryption": {
+        "enabled": false,
+        "modifiable": false
+      }
+    }
+  },
+  "thankyou_screens": [
+    {
+      "id": "Vxwvb1Y03Bsh",
+      "ref": "be7e8121-9449-4993-863a-7fa9326656b9",
+      "title": "Thank you for sharing your health concern with us. After clicking next, you will be taken to a scheduling page.\n\nPlease note: you must have a virtual visit before a home visit can be scheduled.",
+      "type": "thankyou_screen",
+      "properties": {
+        "show_button": false,
+        "share_icons": false,
+        "button_mode": "default_redirect",
+        "button_text": "again"
+      },
+      "attachment": {
+        "type": "image",
+        "href": "https://images.typeform.com/images/AfYbDEsj7NS9"
+      }
+    },
+    {
+      "id": "DefaultTyScreen",
+      "ref": "default_tys",
+      "title": "All done! Thanks for your time.",
+      "type": "thankyou_screen",
+      "properties": {
+        "show_button": false,
+        "share_icons": false
+      }
+    }
+  ],
+  "welcome_screens": [
+    {
+      "id": "NGCT4k03bG7W",
+      "ref": "122872b0-4de9-42c2-9204-fdec922538af",
+      "title": "Hello and thanks for reaching out to your Specialty Healthcare team.  We would like to begin by gathering information on the reason for your visit. You'll be on your way to receiving amazing care in no time. ",
+      "properties": {
+        "show_button": true,
+        "button_text": "Start"
+      },
+      "attachment": {
+        "type": "image",
+        "href": "https://images.typeform.com/images/yFr4FmHbqpzN"
+      }
+    }
+  ],
+  "fields": [
+    {
+      "id": "89Ofk9JaI4M1",
+      "title": "What state do you live in?",
+      "ref": "508ea9df-177c-4cda-8371-8f7cc1bc60a2",
+      "properties": {
+        "randomize": false,
+        "alphabetical_order": true,
+        "choices": [
+          {
+            "id": "eSMBTpzeqJYQ",
+            "ref": "65fd22c3-32ec-4c92-b194-5aef3a10fe60",
+            "label": "Alabama"
+          },
+          {
+            "id": "j3vaogON6nCL",
+            "ref": "06c83fb6-1725-4c64-b555-df84bfa8e978",
+            "label": "Alaska"
+          },
+          {
+            "id": "5mS6qWS1VurN",
+            "ref": "7ce2d4b2-81f7-4cdd-b0ca-f5ec651abbce",
+            "label": "Arizona"
+          },
+          {
+            "id": "0UU1XrRB8l6z",
+            "ref": "7a52c8ec-a27c-40ed-bb5c-adff246798c1",
+            "label": "Arkansas"
+          },
+          {
+            "id": "euq6dBBEOBn0",
+            "ref": "9eca5aaa-95a9-431f-870e-aafb6dfa9a19",
+            "label": "California"
+          },
+          {
+            "id": "0ODqZCwOLS7p",
+            "ref": "f1fbd0f6-ac22-4b59-962b-f1a2abcb0ede",
+            "label": "Colorado"
+          },
+          {
+            "id": "wBWcfgLyBPNs",
+            "ref": "b690abd1-78a6-4346-a353-4236e4fb5965",
+            "label": "Connecticut"
+          },
+          {
+            "id": "y7ATW9nzDGIH",
+            "ref": "1a3456c2-8394-4e19-9122-cd3b6f445c54",
+            "label": "Delaware"
+          },
+          {
+            "id": "8RsWtwFMNQA6",
+            "ref": "bb1754b4-8909-4319-ae7f-98a568ebf9ae",
+            "label": "DC"
+          },
+          {
+            "id": "N7dIxo2y60Ps",
+            "ref": "bc169999-4c23-4bcf-9209-abee3c377b24",
+            "label": "Florida"
+          },
+          {
+            "id": "MzbasL1w5w4q",
+            "ref": "09f795d1-c8e2-43f2-9e9d-5d7c0430c112",
+            "label": "Georgia"
+          },
+          {
+            "id": "L6aOdzSmNCUC",
+            "ref": "6e8a3c11-2a2c-4e6b-b2d3-6ae72df93537",
+            "label": "Hawaii"
+          },
+          {
+            "id": "uM7KnW7MQy6z",
+            "ref": "c25f058f-ada9-4b12-bce4-9f819bbc8bea",
+            "label": "Idaho"
+          },
+          {
+            "id": "q3z9XgphRFoB",
+            "ref": "606e3e08-c234-4828-bd0f-ba69bba908f0",
+            "label": "Illinois"
+          },
+          {
+            "id": "TWGGNmZuW88h",
+            "ref": "68a23247-0658-4e9b-ba07-dc6c65ec7583",
+            "label": "Indiana"
+          },
+          {
+            "id": "yfemQbGpw6w1",
+            "ref": "ddd6f006-8f40-4512-9df0-6c7508a24420",
+            "label": "Iowa"
+          },
+          {
+            "id": "wj9eHLPu7REP",
+            "ref": "da76d9a6-d5d6-4305-b208-78910f2e817a",
+            "label": "Kansas"
+          },
+          {
+            "id": "DJ2276H11VaG",
+            "ref": "2022bac5-499e-421c-beab-cefc336c2bbc",
+            "label": "Kentucky"
+          },
+          {
+            "id": "dSNziDdn0i5M",
+            "ref": "dec3bbdc-afdf-4c46-ae20-a248d023abb2",
+            "label": "Louisiana"
+          },
+          {
+            "id": "lrxLeF2ZO5OT",
+            "ref": "86ea58cc-74c6-4b15-ac6d-9196469d758f",
+            "label": "Maine"
+          },
+          {
+            "id": "KwGAy3lLwzIw",
+            "ref": "8f3bfe75-594c-44e0-845b-656a1a7568c6",
+            "label": "Maryland"
+          },
+          {
+            "id": "1HcPcbyTAV6e",
+            "ref": "aafe8b8f-5f75-4e6a-a369-5c8e49d16029",
+            "label": "Massachusetts"
+          },
+          {
+            "id": "e3zDAUbW0pKR",
+            "ref": "9debe884-3a3f-42b1-84fa-8f6a088e2b44",
+            "label": "Michigan"
+          },
+          {
+            "id": "Rh7fHLNn7tRV",
+            "ref": "aa028c7c-ce34-428f-8563-35bce5201dc1",
+            "label": "Minnesota"
+          },
+          {
+            "id": "akc8IwdCydRA",
+            "ref": "faddfe28-ec7d-4509-92f0-ba61aa83a546",
+            "label": "Mississippi"
+          },
+          {
+            "id": "Q6Hdyx2ZEZfu",
+            "ref": "fd3f8a56-6e0e-4786-8604-b1ff12a8e0a6",
+            "label": "Missouri"
+          },
+          {
+            "id": "OzKx8FepZh5E",
+            "ref": "1d58d3c3-27e6-4b6c-8c96-6e3bafcb512f",
+            "label": "Montana"
+          },
+          {
+            "id": "SMD4onaiOpKt",
+            "ref": "c3608f2a-114c-4274-af42-747332f6578e",
+            "label": "Nebraska"
+          },
+          {
+            "id": "mynqDozyCohh",
+            "ref": "5d8bf798-8068-41e9-956f-2bd03a0d1531",
+            "label": "Nevada"
+          },
+          {
+            "id": "8s3T0HqBAPgi",
+            "ref": "a2877de6-c50b-499a-98a0-a821c4ae047f",
+            "label": "New Hampshire"
+          },
+          {
+            "id": "41IOO5WNmZ6Q",
+            "ref": "2c079aaf-cece-4084-8b8c-8840b1551779",
+            "label": "New Jersey"
+          },
+          {
+            "id": "96X2XFns993o",
+            "ref": "2c575be6-bf1d-4b98-affe-c13fa731bd8b",
+            "label": "New Mexico"
+          },
+          {
+            "id": "hYlihRDULkLC",
+            "ref": "22865522-43a0-4637-acb4-a884f81d18a5",
+            "label": "New York"
+          },
+          {
+            "id": "ybAkFfZ7TLAy",
+            "ref": "9790bfbb-0c81-436a-ac96-38042b6cee2c",
+            "label": "North Carolina"
+          },
+          {
+            "id": "GLKmXdu7AIkA",
+            "ref": "61e2f465-c7c1-4aae-8efb-f764c7276ef6",
+            "label": "North Dakota"
+          },
+          {
+            "id": "i1iil9R4W3uo",
+            "ref": "2fcf9300-4aa5-473e-b04c-c055ea85c44c",
+            "label": "Ohio"
+          },
+          {
+            "id": "mhdzL2DQ8aZb",
+            "ref": "63a1cb8f-ad44-4204-a3ff-46e75060b5d5",
+            "label": "Oklahoma"
+          },
+          {
+            "id": "lY8RLYppi8xc",
+            "ref": "5d164b1f-9ca4-45a0-aee9-47d116501f6d",
+            "label": "Oregon"
+          },
+          {
+            "id": "8g972ihd8iCU",
+            "ref": "daf15a6a-3541-40d6-b016-892356786f27",
+            "label": "Pennsylvania"
+          },
+          {
+            "id": "SkN2bU5SkvTl",
+            "ref": "0ae32179-85ce-422d-a96a-5f24c9c98721",
+            "label": "Rhode Island"
+          },
+          {
+            "id": "YLXDCOzHLLic",
+            "ref": "ad743db6-fe4c-4e8e-8368-f802f51458bd",
+            "label": "South Carolina"
+          },
+          {
+            "id": "TZa6DcxASKOh",
+            "ref": "92d7c4fe-8a93-4d89-be4f-0efda6b47053",
+            "label": "South Dakota"
+          },
+          {
+            "id": "k9Wj80ZU8h95",
+            "ref": "928c6f57-c402-46c5-8c2d-20e48d6331d2",
+            "label": "Tennessee"
+          },
+          {
+            "id": "FvmgeqGtIwr7",
+            "ref": "1d6b4d0f-418a-49e9-aebc-37fbf76f4a7d",
+            "label": "Texas"
+          },
+          {
+            "id": "9UjN11ZSrIkB",
+            "ref": "cab81bbd-17f5-4440-bde9-53f3b60a2cc4",
+            "label": "Utah"
+          },
+          {
+            "id": "PQ3m4zhgb6oN",
+            "ref": "7513a99e-1a90-468a-aa1a-ccd07d356f4c",
+            "label": "Vermont"
+          },
+          {
+            "id": "1OjSLrzCakaD",
+            "ref": "0b63f26f-2f39-4dbd-8266-36cf91928f2a",
+            "label": "Virginia"
+          },
+          {
+            "id": "E55Ts49YtHCW",
+            "ref": "fd4d4b16-9651-4138-9678-9fe6e2646a1c",
+            "label": "Washington"
+          },
+          {
+            "id": "y19mhHfW1aAk",
+            "ref": "370f1bf7-c3ac-438b-9e8d-27d01ef11d5e",
+            "label": "West Virginia"
+          },
+          {
+            "id": "Az5DctqMovNt",
+            "ref": "2c23da0b-a797-45f3-8b8b-fc2109e2b3eb",
+            "label": "Wisconsin"
+          },
+          {
+            "id": "FmjWqF0sNdvH",
+            "ref": "d186f524-49f5-4d30-b32e-f936e0aeea6d",
+            "label": "Wyoming"
+          }
+        ]
+      },
+      "validations": {
+        "required": true
+      },
+      "type": "dropdown"
+    },
+    {
+      "id": "Xt8ZfmaAfAVt",
+      "title": "What state will you be in at the time of your appointment?",
+      "ref": "6156ba3b-1854-4d59-a536-08116c17a4ec",
+      "properties": {
+        "randomize": false,
+        "alphabetical_order": false,
+        "choices": [
+          {
+            "id": "2dVl3OshIYbF",
+            "ref": "a30bbaa5-8fdc-4269-b486-7d4ef7bb942e",
+            "label": "Alabama"
+          },
+          {
+            "id": "8LdXB2yoxc20",
+            "ref": "9d3118e5-a080-4608-8e45-1c89512a6635",
+            "label": "Alaska"
+          },
+          {
+            "id": "nprmuZ0qb5aC",
+            "ref": "7540df82-38fb-4ed1-9937-e2eb737bae42",
+            "label": "Arizona"
+          },
+          {
+            "id": "JYHLsIsgr4XD",
+            "ref": "14fc196c-6c91-4d6a-b7b1-bad62aed4cc9",
+            "label": "Arkansas"
+          },
+          {
+            "id": "921dOt1D5MpP",
+            "ref": "3783c9dd-76a2-4a21-874a-95718c09d551",
+            "label": "California"
+          },
+          {
+            "id": "pn29RBee7X4o",
+            "ref": "8bff1932-81fd-4f62-89dd-1582a605077a",
+            "label": "Colorado"
+          },
+          {
+            "id": "YLmQPp8adr3V",
+            "ref": "69730c1e-a1b0-4ffd-adcf-60160424dbf1",
+            "label": "Connecticut"
+          },
+          {
+            "id": "eBOcop6kZ9kt",
+            "ref": "b5321517-ecd2-41ed-866a-2aeb0d60eeef",
+            "label": "Delaware"
+          },
+          {
+            "id": "G8UfPBvXSf3K",
+            "ref": "d1169fb2-283f-4827-9f08-4bac88c4aebe",
+            "label": "DC"
+          },
+          {
+            "id": "QjwnW4eYEGIm",
+            "ref": "3ca2cb7a-2427-41bc-b556-1ff7bad96b15",
+            "label": "Florida"
+          },
+          {
+            "id": "AlSrLu9XnTmH",
+            "ref": "55f72194-1564-4187-81c0-66b3ca963528",
+            "label": "Georgia"
+          },
+          {
+            "id": "j7CeCZvYtuL0",
+            "ref": "82c25c63-92d1-4e37-8913-99caf05ad886",
+            "label": "Hawaii"
+          },
+          {
+            "id": "umKttZVxz9ER",
+            "ref": "396db0ff-1cb7-4747-9ef2-1fbb78b93999",
+            "label": "Idaho"
+          },
+          {
+            "id": "MpmRLCWyoEKL",
+            "ref": "670556fa-f584-4317-ac69-6221bbd47d94",
+            "label": "Illinois"
+          },
+          {
+            "id": "0l1drYGWExjM",
+            "ref": "6d5ca16c-afee-4361-9cdf-afae0209dedb",
+            "label": "Indiana"
+          },
+          {
+            "id": "skXKSDKJrFtJ",
+            "ref": "8fa0239b-adfc-43e6-83eb-2a7ccef4563a",
+            "label": "Iowa"
+          },
+          {
+            "id": "WhkVdWDtj2ye",
+            "ref": "a1db3794-df64-405d-9a2d-5f8a95dc8f15",
+            "label": "Kansas"
+          },
+          {
+            "id": "7XGtC92Xg4pU",
+            "ref": "508f12b8-1b8e-45dc-8362-cae0ee02c4ca",
+            "label": "Kentucky"
+          },
+          {
+            "id": "eMx4f6zfbz7M",
+            "ref": "29d238a0-e2ef-4590-b1fe-2d99fbca1c6b",
+            "label": "Louisiana"
+          },
+          {
+            "id": "6LyJ3yuKeLCp",
+            "ref": "3c8a8877-5ce5-43f3-ac7e-60031f9295e4",
+            "label": "Maine"
+          },
+          {
+            "id": "GZDhefVB29LJ",
+            "ref": "041b2956-b4ef-496c-989a-40ad6b79d059",
+            "label": "Maryland"
+          },
+          {
+            "id": "2AACbHcvL30V",
+            "ref": "6bd30bad-e1bb-4049-b12f-857a91562bee",
+            "label": "Massachusetts"
+          },
+          {
+            "id": "hMtPOKawxcrx",
+            "ref": "ff18fe0c-1f73-442a-b87c-f9b31e813be5",
+            "label": "Michigan"
+          },
+          {
+            "id": "pfISXwBytk0P",
+            "ref": "d62ec47b-624e-417f-b4d0-4a8886d09e78",
+            "label": "Minnesota"
+          },
+          {
+            "id": "L0xSf6eEAzcL",
+            "ref": "9dbc9cc1-899b-45e9-8ddf-7739ebfafbc7",
+            "label": "Mississippi"
+          },
+          {
+            "id": "zEJLIMSCNpcL",
+            "ref": "eacbedc7-0f5d-4cb9-b890-14e091a3febc",
+            "label": "Missouri"
+          },
+          {
+            "id": "dj3OkoKJFzw1",
+            "ref": "70a8d98b-7d12-4fff-916f-95e98ff40cac",
+            "label": "Montana"
+          },
+          {
+            "id": "e7myoZZcDuuY",
+            "ref": "9e7f4dee-0b40-4fcd-937a-3e0303736c08",
+            "label": "Nebraska"
+          },
+          {
+            "id": "8yQbTJJVcv58",
+            "ref": "01578523-a80a-4539-86f0-93ccd77cdd95",
+            "label": "Nevada"
+          },
+          {
+            "id": "4YuDZSFcs5ZE",
+            "ref": "0ecfc688-ac4a-46fb-aa12-7760948d32b3",
+            "label": "New Hampshire"
+          },
+          {
+            "id": "qw4W3vEb9qIm",
+            "ref": "955c749e-9929-4b19-8dab-06597fbf4ffc",
+            "label": "New Jersey"
+          },
+          {
+            "id": "5QUIzjE9xazB",
+            "ref": "7cc90aa8-6f24-49eb-ab64-f14dd3df2f30",
+            "label": "New Mexico"
+          },
+          {
+            "id": "NyJSnJQsszwD",
+            "ref": "2b46c5a3-497b-4887-8793-936e5249c20e",
+            "label": "New York"
+          },
+          {
+            "id": "Q5xvYrX9xe7R",
+            "ref": "ed774b5e-1c4d-4573-81b8-4ea126b7b201",
+            "label": "North Carolina"
+          },
+          {
+            "id": "Zgxa4Gv7kTjo",
+            "ref": "bbee5625-11fe-4762-b658-90199a071156",
+            "label": "North Dakota"
+          },
+          {
+            "id": "rLT2GNrmwEtq",
+            "ref": "4bbd1095-a964-495d-a6b3-f2e9df189fe6",
+            "label": "Ohio"
+          },
+          {
+            "id": "5r3ZNMO1g8eS",
+            "ref": "a69009f1-dc68-4a6e-8f28-6239ca8c0e12",
+            "label": "Oklahoma"
+          },
+          {
+            "id": "TpUXxVJa9CfE",
+            "ref": "b5b13699-2834-4188-9f04-510f5df7d152",
+            "label": "Oregon"
+          },
+          {
+            "id": "5l5BuNLXWaaW",
+            "ref": "38d139d0-6a2f-4c3c-a6f9-82660d696bcf",
+            "label": "Pennsylvania"
+          },
+          {
+            "id": "T7m06ud4ZwR0",
+            "ref": "1f8a3031-225a-4c3c-bf31-633cc12ec3ff",
+            "label": "Rhode Island"
+          },
+          {
+            "id": "P5SaBv6cVrJz",
+            "ref": "0153d1fd-e8bb-4390-a194-66ebef2fd221",
+            "label": "South Carolina"
+          },
+          {
+            "id": "RgmdZzdhfCOV",
+            "ref": "1e1cb047-1d51-4afb-a96b-81734a6b324e",
+            "label": "South Dakota"
+          },
+          {
+            "id": "btNInpkcaGCG",
+            "ref": "700ae07c-da41-476e-896a-60caea1cef38",
+            "label": "Tennessee"
+          },
+          {
+            "id": "xamK0GbloUkr",
+            "ref": "166ef976-eec9-4d7a-802e-f1d6cb427919",
+            "label": "Texas"
+          },
+          {
+            "id": "vzXSYmeje0ee",
+            "ref": "4e77bcd9-37e1-4210-a2be-19775cf11c59",
+            "label": "Utah"
+          },
+          {
+            "id": "7U0WSkU5XQD4",
+            "ref": "dd672bee-4877-49e5-b269-639ded86718a",
+            "label": "Vermont"
+          },
+          {
+            "id": "fMz4DXXNcImk",
+            "ref": "500ebd5f-31a3-4209-a7ed-e5f7830ab846",
+            "label": "Virginia"
+          },
+          {
+            "id": "FnZTXTk97bU6",
+            "ref": "de640daa-7976-4b4a-82f6-d5598a7c2678",
+            "label": "Washington"
+          },
+          {
+            "id": "iRkt93UlMDxJ",
+            "ref": "4d094d2f-2f8e-4a01-98ba-6ec7795a0af0",
+            "label": "West Virginia"
+          },
+          {
+            "id": "IRoSU7lwqcFU",
+            "ref": "3334f7e8-e0d8-4ec9-b7c0-b0dac0e8cb34",
+            "label": "Wisconsin"
+          },
+          {
+            "id": "lgymVGvk5Jvb",
+            "ref": "b658db94-fb99-4c4e-ad64-7a268bc6e5a6",
+            "label": "Wyoming"
+          }
+        ]
+      },
+      "validations": {
+        "required": true
+      },
+      "type": "dropdown"
+    },
+    {
+      "id": "lMd3J8Dhdtxx",
+      "title": "Sorry, Specialty Healthcare is not licensed to treat people in your state of residence and/or current physical location.",
+      "ref": "744aaf59-5f8e-47ec-93ee-4053e705e808",
+      "properties": {
+        "button_text": "Continue",
+        "hide_marks": false
+      },
+      "type": "statement"
+    },
+    {
+      "id": "0mMHJCj4JoPr",
+      "title": "If you are experiencing a medical emergency, please call 911 or seek immediate medical attention.",
+      "ref": "8cd03d7e-412f-4be4-9e80-281f66675fca",
+      "properties": {
+        "description": "Signs of an emergency may include:\n\n• Active suicidal/homicidal feelings\n\n• Chest pain or heart attack symptoms \n\n• Significant difficulty breathing\n\n• Stroke symptoms (facial drooping, arm weakness, speech difficulty)\n\n• Severe allergic reaction\n\n• Fever greater than 104.5°F\n\n• Coughing or vomiting blood\n\n• Sudden, severe, uncontrolled pain\n\n• Severe headache\n\n• Loss of consciousness/changes in mental status\n\n• Poisoning/inhalation of substances\n\n• Moderate to severe wounds/burns\n\n• Seizures\n\n• Significant trauma/head injury\n\n•Pregnancy complications (vaginal bleeding, cramping, or abdominal pain)",
+        "button_text": "Acknowledge \u0026 Continue",
+        "hide_marks": false
+      },
+      "type": "statement"
+    },
+    {
+      "id": "sjRF0hu0scyS",
+      "title": "Please select the patient's age category:",
+      "ref": "4915db69-55ca-4a00-b57e-893d7ea3e761",
+      "properties": {
+        "randomize": false,
+        "allow_multiple_selection": false,
+        "allow_other_choice": false,
+        "vertical_alignment": true,
+        "choices": [
+          {
+            "id": "g33MhlfdwCmK",
+            "ref": "2f202927-97b2-4d9c-aaef-1296fb68c5ba",
+            "label": "Minor, age 12 or under"
+          },
+          {
+            "id": "13ooIeAEibNz",
+            "ref": "e6a75660-04b1-445a-bdd4-13b95e5a2114",
+            "label": "Minor, 13-17 years of age"
+          },
+          {
+            "id": "QQP6V2LnuOBK",
+            "ref": "a66c1065-4e4f-46fc-8a26-794cc46a59f9",
+            "label": "Adult, 18-64 years of age"
+          },
+          {
+            "id": "FunQo3YVznuO",
+            "ref": "99ae9cf5-3767-461e-a84f-3da8b7e36165",
+            "label": "Medicare Eligible, 65+ years of age"
+          }
+        ]
+      },
+      "validations": {
+        "required": false
+      },
+      "type": "multiple_choice"
+    },
+    {
+      "id": "FfDbA5uPJJVi",
+      "title": "Will a legal guardian be present at the time of the video or chat visit?",
+      "ref": "f55dd9ee-6bcd-4438-b61a-9766e38da976",
+      "properties": {},
+      "validations": {
+        "required": false
+      },
+      "type": "yes_no"
+    },
+    {
+      "id": "PKXJj7GrISQe",
+      "title": "Thank you, a consent form has been sent to the default account holder. Please continue so we can finish setting up your appointment.",
+      "ref": "d3f1729c-cf2a-4395-b0bc-60212ab9bf1a",
+      "properties": {
+        "button_text": "Continue",
+        "hide_marks": false
+      },
+      "type": "statement"
+    },
+    {
+      "id": "mfyfrFC7Y1Jy",
+      "title": "Patients 12 and under must have a legal guardian present for chat, virtual or home visits.",
+      "ref": "f4040a6a-7c46-4f22-a659-61bf9c713cdc",
+      "properties": {
+        "button_text": "Continue",
+        "hide_marks": false
+      },
+      "type": "statement"
+    },
+    {
+      "id": "0QSfTuGGV8W5",
+      "title": "Please select the patient's biological sex:",
+      "ref": "c09778dd-d584-40cc-8517-a627592ca5f1",
+      "properties": {
+        "description": "Knowing a person's biological sex (biological chromosomes) is essential for safe medical treatment. Please send us your gender, preferred pronouns, and/or preferred name through the Specialty Healthcare app chat so that we can make you more comfortable.",
+        "randomize": false,
+        "allow_multiple_selection": false,
+        "allow_other_choice": false,
+        "vertical_alignment": true,
+        "choices": [
+          {
+            "id": "sMS71WYh4uwZ",
+            "ref": "afd3955c-0510-4df4-9ba5-1f6603f1436e",
+            "label": "Female"
+          },
+          {
+            "id": "0lMWpTMsLVhH",
+            "ref": "a5e3cd94-58f6-4701-8632-dc3cc030dde5",
+            "label": "Male"
+          }
+        ]
+      },
+      "validations": {
+        "required": true
+      },
+      "type": "multiple_choice"
+    },
+    {
+      "id": "HBQLyk2DWevZ",
+      "title": "If you are the parent or legal guardian of a minor (under 18) needing care, please answer all medical questions in regards to the patient, not yourself.",
+      "ref": "5db25282-6779-46dd-8667-ea52a630056a",
+      "properties": {
+        "button_text": "Continue",
+        "hide_marks": false
+      },
+      "type": "statement"
+    },
+    {
+      "id": "YU1nWbUb7YJv",
+      "title": "What was a recent height (in inches)?",
+      "ref": "56efbdb0-ee25-4759-9635-da92debcda7d",
+      "properties": {
+        "description": "This is important to know in case your child needs a medication. If you absolutely don't know you can leave blank."
+      },
+      "validations": {
+        "required": false
+      },
+      "type": "number"
+    },
+    {
+      "id": "ilO7rir0yJB7",
+      "title": "What was a recent weight (in pounds)?  ",
+      "ref": "a0583989-a940-4d3c-9151-86d5efa18bc0",
+      "properties": {
+        "description": "This is important to know in case your child needs a medication. If you absolutely don't know you can leave blank."
+      },
+      "validations": {
+        "required": false
+      },
+      "type": "number"
+    },
+    {
+      "id": "wn9EH9EqXMdD",
+      "title": "Health History",
+      "ref": "778d214e-b9e1-4fca-a0ed-922369858b36",
+      "properties": {
+        "button_text": "Continue",
+        "show_button": false,
+        "fields": [
+          {
+            "id": "010tDgDXHUnn",
+            "title": "Has a medical history form ever been completed and submitted to the patient's Specialty Healthcare team? ",
+            "ref": "7f57a989-19d3-40b8-af66-d022d3ebb73f",
+            "properties": {},
+            "validations": {
+              "required": false
+            },
+            "type": "yes_no"
+          },
+          {
+            "id": "eLALYF4Clp7b",
+            "title": "Did you have any updates for your provider to add to the previous medical history? ",
+            "ref": "5d99768b-65af-4f68-9939-87dfbd29f49a",
+            "properties": {
+              "description": "This could be a change in medications, recent illness or hospitalization, change in family history, surgeries, etc."
+            },
+            "validations": {
+              "required": false
+            },
+            "type": "yes_no"
+          },
+          {
+            "id": "KBHEjvraGBOd",
+            "title": "What updates would you like to share? ",
+            "ref": "d507cc27-5716-4b21-ae06-abaa5a55ee19",
+            "properties": {},
+            "validations": {
+              "required": false
+            },
+            "type": "long_text"
+          },
+          {
+            "id": "7sYaoqW3WLzi",
+            "title": "We would really appreciate if you could take a few moments and complete a brief medical history. ",
+            "ref": "09c640b9-37b7-452e-a5a8-f2db8d0fda12",
+            "properties": {
+              "button_text": "Continue",
+              "hide_marks": false
+            },
+            "type": "statement"
+          }
+        ]
+      },
+      "type": "group"
+    },
+    {
+      "id": "AMZIaASSlWZK",
+      "title": "General Health History Questions",
+      "ref": "b0b2c653-d681-4472-b13c-b132607eb94c",
+      "properties": {
+        "button_text": "Continue",
+        "show_button": false,
+        "fields": [
+          {
+            "id": "ZLoV6vBb2hDm",
+            "title": "Do you have a history of or currently have any of the following medical conditions/concerns?",
+            "ref": "bb4445c2-e5fb-43b4-904e-2b18225319ba",
+            "properties": {
+              "randomize": false,
+              "allow_multiple_selection": true,
+              "allow_other_choice": false,
+              "vertical_alignment": true,
+              "choices": [
+                {
+                  "id": "BfPleOlbPTtU",
+                  "ref": "9c02faba-8a92-4431-9c4c-12da6322536c",
+                  "label": "Healthy, no medical concerns/conditions"
+                },
+                {
+                  "id": "CR27d49LvMth",
+                  "ref": "2e0e2837-9adb-4c8b-bc05-7791606a8ec1",
+                  "label": "Asthma / Reactive Airway Disease"
+                },
+                {
+                  "id": "3YJe8fpGj91E",
+                  "ref": "4905a831-2f2f-47e8-ad50-511bc8ff7368",
+                  "label": "Autoimmune conditions"
+                },
+                {
+                  "id": "Eg07xcBa3psY",
+                  "ref": "4e1059dc-e6df-405f-a06a-e814cd95f74f",
+                  "label": "Cancer"
+                },
+                {
+                  "id": "ArmpYT7Ukdzw",
+                  "ref": "4e8e10b8-d8f5-40b1-b762-57ef55634aa9",
+                  "label": "Heart defects or issues"
+                },
+                {
+                  "id": "jDXHsjJmgpQ6",
+                  "ref": "abd04087-089c-4f14-956f-83a30424c554",
+                  "label": "Joint or bone issues"
+                },
+                {
+                  "id": "9ZH4S9AutSvx",
+                  "ref": "5d1e9387-b3e6-4f73-aad7-1fbe94af8c8d",
+                  "label": "Vision and/or eye issues"
+                },
+                {
+                  "id": "eIv8ilBg0mLL",
+                  "ref": "0eb0d174-eeac-4078-9a23-a90d52d63ce4",
+                  "label": "Hearing and/or ear issues"
+                },
+                {
+                  "id": "HHKMI6TZTxEm",
+                  "ref": "8896fd2e-781b-483a-819a-52aa5c8726fd",
+                  "label": "Premature birth"
+                },
+                {
+                  "id": "AP3JNM0g5EMm",
+                  "ref": "42d3b41e-6482-41a5-a77a-d65b865655cc",
+                  "label": "High blood pressure issues"
+                },
+                {
+                  "id": "viyXq0ECLb3B",
+                  "ref": "dc13b1d3-fc81-4db2-938b-dd95513b2c22",
+                  "label": "Thyroid issues"
+                },
+                {
+                  "id": "BHgeAiAWoRWE",
+                  "ref": "b8ed679a-5fd3-4d1a-b41d-7aa0483e1160",
+                  "label": "High cholesterol issues"
+                },
+                {
+                  "id": "LYHucUvb6dTp",
+                  "ref": "ed16384f-1bb3-46eb-9d3e-8c07597d651c",
+                  "label": "Diabetes or other blood sugar issues"
+                },
+                {
+                  "id": "JJca8cuB9VqS",
+                  "ref": "43869780-cf55-45b8-b6be-9c1c8aaf8783",
+                  "label": "Mental health concerns (depression, anxiety, etc.)"
+                },
+                {
+                  "id": "479A6oJiDNTG",
+                  "ref": "6a4b2f33-2c83-4976-a341-a2eb81f2fc6e",
+                  "label": "Other"
+                }
+              ]
+            },
+            "validations": {
+              "required": true
+            },
+            "type": "multiple_choice"
+          },
+          {
+            "id": "HGwWvP19R8Iz",
+            "title": "Please list what other conditions you have or have had:",
+            "ref": "39b2633b-7d5d-4f2f-b92a-be6101ec91d8",
+            "properties": {},
+            "validations": {
+              "required": false
+            },
+            "type": "short_text"
+          },
+          {
+            "id": "t7TAQWrSxRnx",
+            "title": "Please explain or add any additional details about the conditions selected: ",
+            "ref": "5102aafe-809a-4977-b18e-e9037af84575",
+            "properties": {
+              "description": "Such as how old when diagnosed, current or past condition, etc."
+            },
+            "validations": {
+              "required": false
+            },
+            "type": "long_text"
+          },
+          {
+            "id": "PUb2LxvWW7gr",
+            "title": "Are any medications or supplements taken on a regular basis?",
+            "ref": "42aedcc2-af25-4016-9f17-d521007c3a2f",
+            "properties": {},
+            "validations": {
+              "required": true
+            },
+            "type": "yes_no"
+          },
+          {
+            "id": "EPX7Hl4bUYj8",
+            "title": "To the best of your ability, please list the medications and/or supplements, each one's dose and the directions for taking them:",
+            "ref": "3d9c7bec-b7f9-4760-bc16-6312b95f677d",
+            "properties": {},
+            "validations": {
+              "required": false
+            },
+            "type": "long_text"
+          },
+          {
+            "id": "r8xCzWOx4Zab",
+            "title": "Any medication allergies?",
+            "ref": "6f999cc5-0c01-41e1-82f5-8d1eaf127ae5",
+            "properties": {},
+            "validations": {
+              "required": true
+            },
+            "type": "yes_no"
+          },
+          {
+            "id": "3zEKsd9DLYkb",
+            "title": "Please list the allergies and what happened when the medication was taken if you know that information: ",
+            "ref": "a6521f1c-0bcc-4163-9373-c286a34dd2ca",
+            "properties": {
+              "description": "For example \"I develop hives with penicillin\""
+            },
+            "validations": {
+              "required": false
+            },
+            "type": "short_text"
+          },
+          {
+            "id": "tsKldi7KcdaV",
+            "title": "Is there a history of any past surgeries?",
+            "ref": "cb42a04e-04e6-40c3-b96a-33cc66c2f02f",
+            "properties": {},
+            "validations": {
+              "required": true
+            },
+            "type": "yes_no"
+          },
+          {
+            "id": "OdopRl2V8Ome",
+            "title": "What surgeries were completed and what was the approximate year?",
+            "ref": "15e1a76c-e053-47bc-9b5b-2ce0682684dc",
+            "properties": {},
+            "validations": {
+              "required": false
+            },
+            "type": "short_text"
+          },
+          {
+            "id": "Xjq9a8cFbYgA",
+            "title": "Please list any significant family medical history and who had the condition(s): ",
+            "ref": "bc8dffad-347b-472c-a9c0-1eb8986e12d6",
+            "properties": {
+              "description": "Include BIOLOGICAL parents, siblings and/or grandparents only. You may write \"none\" or \"unknown\"."
+            },
+            "validations": {
+              "required": false
+            },
+            "type": "long_text"
+          }
+        ]
+      },
+      "type": "group"
+    },
+    {
+      "id": "2s5THmVLUgON",
+      "title": "Children Health History Questions",
+      "ref": "31800457-2f96-4552-a3c2-b4e8420d5f5b",
+      "properties": {
+        "button_text": "Continue",
+        "show_button": false,
+        "fields": [
+          {
+            "id": "08UrBcmVeWqm",
+            "title": "What best describes your child's immunization status?",
+            "ref": "8f12bc86-776d-4aa6-bf64-bba6cee1e9db",
+            "properties": {
+              "randomize": false,
+              "allow_multiple_selection": false,
+              "allow_other_choice": false,
+              "vertical_alignment": true,
+              "choices": [
+                {
+                  "id": "Ph4YdKgvRIev",
+                  "ref": "893e2517-3eda-47ed-8c06-a38135013f64",
+                  "label": "Up to date on immunizations"
+                },
+                {
+                  "id": "8JzptO1AI53a",
+                  "ref": "4ea6a0b9-d9cd-41ed-9889-21c0f5047ec0",
+                  "label": "Not up to date on immunizations"
+                },
+                {
+                  "id": "OsvArIAmagdD",
+                  "ref": "83955434-61c1-4f99-9a16-9e1f7e459bb4",
+                  "label": "I/We choose not to immunize"
+                },
+                {
+                  "id": "ANCIIpSqlPeO",
+                  "ref": "f869ea46-ac73-47ae-9df4-c5559b003528",
+                  "label": "Our child medically cannot have all immunizations"
+                },
+                {
+                  "id": "p4pHWmXyBnGN",
+                  "ref": "7f8e9ef5-f66a-4825-a38c-8febcd39683c",
+                  "label": "Unsure"
+                }
+              ]
+            },
+            "validations": {
+              "required": false
+            },
+            "type": "multiple_choice"
+          },
+          {
+            "id": "hhIw3ejGs6kZ",
+            "title": "Is anyone in the household a smoker? ",
+            "ref": "c080588e-4846-4c28-8aa8-3a564d02d2e2",
+            "properties": {},
+            "validations": {
+              "required": false
+            },
+            "type": "yes_no"
+          },
+          {
+            "id": "sNqPbdJRo5Mp",
+            "title": "Does this person smoke:",
+            "ref": "1232777d-45f5-424e-b972-0c988e8a03fd",
+            "properties": {
+              "randomize": false,
+              "allow_multiple_selection": true,
+              "allow_other_choice": false,
+              "vertical_alignment": true,
+              "choices": [
+                {
+                  "id": "vqOMN2eMIBoZ",
+                  "ref": "3d0d8813-7e4d-49b9-aa02-0c5bd9372905",
+                  "label": "In the home"
+                },
+                {
+                  "id": "aREHQRAk3hFP",
+                  "ref": "d0e107f7-c1a5-4f45-9b27-6ee87dde3be7",
+                  "label": "Outside of the home"
+                },
+                {
+                  "id": "5eRaVbB12MtL",
+                  "ref": "89cef8ec-2e29-4102-b131-b2596f1838ab",
+                  "label": "In the car"
+                }
+              ]
+            },
+            "validations": {
+              "required": false
+            },
+            "type": "multiple_choice"
+          }
+        ]
+      },
+      "type": "group"
+    },
+    {
+      "id": "g0Zzf4YcH2bv",
+      "title": "Female Health History Questions",
+      "ref": "02115986-9afa-4581-90a7-d3d4b994129e",
+      "properties": {
+        "button_text": "Continue",
+        "show_button": false,
+        "fields": [
+          {
+            "id": "wD0RRw9QB8iI",
+            "title": "Please select one of the following options:",
+            "ref": "fdd229a5-0bf4-4869-a38c-867cb3dbc488",
+            "properties": {
+              "randomize": false,
+              "allow_multiple_selection": true,
+              "allow_other_choice": false,
+              "vertical_alignment": true,
+              "choices": [
+                {
+                  "id": "3TMpV28LpC9g",
+                  "ref": "2515e267-c610-4ba2-a822-bec70c961576",
+                  "label": "There is no chance of pregnancy and I am not breastfeeding"
+                },
+                {
+                  "id": "q4xnzgkRUDm5",
+                  "ref": "471678b8-9cec-4d03-a49d-7ab7a455fd03",
+                  "label": "There is a chance of pregnancy"
+                },
+                {
+                  "id": "3FV9wUY96KCI",
+                  "ref": "07d37bcb-b12f-485b-9ff1-a795e588282d",
+                  "label": "I am currently pregnant"
+                },
+                {
+                  "id": "OtUbhzl2yyxW",
+                  "ref": "7292bb0f-4c79-440a-a551-5ac9772d1840",
+                  "label": "I am currently breastfeeding"
+                }
+              ]
+            },
+            "validations": {
+              "required": false
+            },
+            "type": "multiple_choice"
+          },
+          {
+            "id": "C02jPBAHR0En",
+            "title": "Date your last menstrual cycle started:",
+            "ref": "97906f9c-408e-4043-9add-e36680708e95",
+            "properties": {
+              "description": "Leave blank if you have never had one or you do not know.",
+              "separator": "/",
+              "structure": "MMDDYYYY"
+            },
+            "validations": {
+              "required": false
+            },
+            "type": "date"
+          }
+        ]
+      },
+      "type": "group"
+    },
+    {
+      "id": "f9cdkUvbzKjP",
+      "title": "Adult Health History Questions",
+      "ref": "799863f0-b4fe-4267-97c0-05292c88a926",
+      "properties": {
+        "button_text": "Continue",
+        "show_button": false,
+        "fields": [
+          {
+            "id": "l1PdRltzu8gu",
+            "title": "Are you currently or were you ever a tobacco user?",
+            "ref": "4367ffe0-1053-4a6e-9f50-b5e66da908cd",
+            "properties": {},
+            "validations": {
+              "required": false
+            },
+            "type": "yes_no"
+          },
+          {
+            "id": "Jo1NoBnIQLc2",
+            "title": "What best describes your current or former tobacco use?",
+            "ref": "4980325d-2ecf-413f-b978-1270dc707c79",
+            "properties": {
+              "randomize": false,
+              "allow_multiple_selection": false,
+              "allow_other_choice": false,
+              "vertical_alignment": true,
+              "choices": [
+                {
+                  "id": "XyLM7PCeRdjs",
+                  "ref": "0bef2454-ae52-4c48-8a36-24c82f4c05bc",
+                  "label": "I currently smoke 1-10 cigarettes every day"
+                },
+                {
+                  "id": "cmTpMmxlOuM0",
+                  "ref": "5cf93941-aa9d-4b2c-a9cc-8155b8352ec6",
+                  "label": "I currently smoke 10-20 cigarettes every day"
+                },
+                {
+                  "id": "TDvhUy3I8DLc",
+                  "ref": "507fa3ff-e65f-4e97-a6c2-fa57c3612790",
+                  "label": "I currently smoke 20 or more cigarettes  every day"
+                },
+                {
+                  "id": "d4aUp1XAIe9T",
+                  "ref": "e554b2c9-17e7-4cf3-be17-b332b582107b",
+                  "label": "I smoke cigarettes a few times a week"
+                },
+                {
+                  "id": "6fHrROTZGXlO",
+                  "ref": "ca221fef-ad4e-4689-9a9e-b87557b12480",
+                  "label": "I use smokeless chewing tobacco every day"
+                },
+                {
+                  "id": "pO69FYWbktiz",
+                  "ref": "432becb7-eb3c-4d0a-99ae-09138cafb636",
+                  "label": "I use smokeless chewing tobacco a few times a week"
+                },
+                {
+                  "id": "Hg62CKAVmPjv",
+                  "ref": "f179dda3-3f7b-4ae0-866a-1481c4b6cda9",
+                  "label": "I am a former tobacco user"
+                }
+              ]
+            },
+            "validations": {
+              "required": false
+            },
+            "type": "multiple_choice"
+          },
+          {
+            "id": "cdBKrC0H8XAW",
+            "title": "When did you quit using tobacco?",
+            "ref": "be288874-040c-4223-8861-001d42f2e8a6",
+            "properties": {},
+            "validations": {
+              "required": false
+            },
+            "type": "short_text"
+          },
+          {
+            "id": "MgVtGTV6KATp",
+            "title": "How many years in total did you use tobacco?",
+            "ref": "439d93e3-6f19-4b2e-8107-e5a188ad533e",
+            "properties": {},
+            "validations": {
+              "required": false
+            },
+            "type": "short_text"
+          },
+          {
+            "id": "lL6NgXctjwTs",
+            "title": "What type of tobacco and how much per day did you use?",
+            "ref": "ba392480-b263-4617-a26c-858e5f2f8387",
+            "properties": {
+              "description": "This includes cigarettes, cigars, smokeless, etc."
+            },
+            "validations": {
+              "required": false
+            },
+            "type": "short_text"
+          }
+        ]
+      },
+      "type": "group"
+    },
+    {
+      "id": "DT8lHiYCO1uH",
+      "title": "What is the primary reason for seeking care today? ",
+      "ref": "aea7a268-64d4-4f16-920a-b9afe317e3b6",
+      "properties": {
+        "randomize": false,
+        "allow_multiple_selection": false,
+        "allow_other_choice": false,
+        "vertical_alignment": true,
+        "choices": [
+          {
+            "id": "oJxHibrPdtHL",
+            "ref": "3faf5f88-5171-4933-af0f-210716bf1a60",
+            "label": "A health issue like an illness or injury that is new, started recently (aka \"Acute\"), and you haven't discussed with a Specialty medical provider in the past (examples include sore throat, cough, urinary symptoms, etc.)"
+          },
+          {
+            "id": "iNlDZtoTuABP",
+            "ref": "173074a1-75b3-45d2-a6d6-298bfa2bb825",
+            "label": "A health issue that you've had ongoing (aka \"Chronic\") or that you suspect you have that you haven't discussed with a Specialty medical provider (examples include diabetes, thyroid, high blood pressure, depression, anxiety, medication management, etc.)"
+          },
+          {
+            "id": "9qpQiZzlgoep",
+            "ref": "4f6732f3-d3b6-4c83-9c3e-a4945a004507",
+            "label": "An update or follow-up on how you are feeling regarding an illness or injury that was discussed with a Specialty medical provider"
+          },
+          {
+            "id": "8skDx0wiDyPL",
+            "ref": "014b478f-eed1-4329-8d4f-8b89335a3faf",
+            "label": "An update, follow-up or medication refill for a chronic or ongoing condition that you have already been partnering with a Specialty provider to help manage."
+          },
+          {
+            "id": "X49aXSxVO70L",
+            "ref": "9c7f877f-b66b-4559-b572-557b60157a3c",
+            "label": "A wellness or preventive visit such as an annual physical, wellness coaching, contraception/birth control, etc."
+          },
+          {
+            "id": "yWSgkBAflcHd",
+            "ref": "c9291e36-0cf3-454c-b9f6-c96538ef6b5f",
+            "label": "A follow-up visit for continued wellness coaching"
+          },
+          {
+            "id": "G7rOHm4ChAAo",
+            "ref": "8ff81563-9786-44c5-8f1a-3aa17d7929e5",
+            "label": "A follow-up visit for contraception/birth control"
+          },
+          {
+            "id": "EmhtukVTUM7b",
+            "ref": "415b4154-14c4-425f-8d0f-a1a1a1ee7cc3",
+            "label": "A biometric coaching session/biometric results review"
+          }
+        ]
+      },
+      "validations": {
+        "required": true
+      },
+      "type": "multiple_choice"
+    },
+    {
+      "id": "lQJgL5ozFyCs",
+      "title": "Acute Concerns",
+      "ref": "1166ddfc-3190-4977-be74-f17882063265",
+      "properties": {
+        "button_text": "Continue",
+        "show_button": false,
+        "fields": [
+          {
+            "id": "1IIWq17Q1bBd",
+            "title": "Which of the following issues best describes your primary area of concern? ",
+            "ref": "b6d10646-9cc9-4ad6-a29e-f5e76f155388",
+            "properties": {
+              "randomize": false,
+              "allow_multiple_selection": false,
+              "allow_other_choice": true,
+              "vertical_alignment": true,
+              "choices": [
+                {
+                  "id": "VMdj2ngtEY9g",
+                  "ref": "dc366d08-9d69-4ac8-9d44-9ca064d45955",
+                  "label": "Allergies (Seasonal / Allergic Rhinitis)"
+                },
+                {
+                  "id": "GMhqrtRyUMl0",
+                  "ref": "e53af6e4-c4f5-48da-832b-d359eb8e8f82",
+                  "label": "Bladder Infection / Urinary Tract Infection Symptoms"
+                },
+                {
+                  "id": "7smVffQwIpAq",
+                  "ref": "c4787ace-a19d-4acd-8401-1b1f3c94946c",
+                  "label": "Cough, Cold, or Respiratory (breathing/lung) concerns"
+                },
+                {
+                  "id": "9Oekp9XkJVzJ",
+                  "ref": "3a34b42a-b86a-44f8-be3d-20f0ca631029",
+                  "label": "Ear Pain or other Ear Concern"
+                },
+                {
+                  "id": "1qn70evTfCNd",
+                  "ref": "a8160cb7-3369-4bd9-b676-4f768d7449e6",
+                  "label": "Rash or other Skin Concern"
+                },
+                {
+                  "id": "KoJIMNwhP7fy",
+                  "ref": "4d5bb0d0-267e-496e-b3dc-d03ce1691422",
+                  "label": "Respiratory Flu (influenza-like) Symptoms"
+                },
+                {
+                  "id": "sYxi5edMlhg8",
+                  "ref": "352e97be-4ffd-44f7-9979-20a424d8997d",
+                  "label": "Sinus Symptoms"
+                },
+                {
+                  "id": "huIcSyBEdyzB",
+                  "ref": "29435820-4262-4463-8586-b77ff5e11023",
+                  "label": "Sore Throat"
+                },
+                {
+                  "id": "jK4ZmM9NrgHn",
+                  "ref": "7ed34b43-91cc-4a15-aa62-ad2ef9bfd4a9",
+                  "label": "Vaginal Yeast or Bacterial Infection Symptoms"
+                },
+                {
+                  "id": "XRyTlLT7ea0p",
+                  "ref": "dfadeff2-becd-4bf1-ac09-44a2b67c09b4",
+                  "label": "Conjunctivitis \"Pink Eye\" or Stye Symptoms"
+                },
+                {
+                  "id": "nW4G4xeFe4dM",
+                  "ref": "a777d6d9-939a-4b6c-a1aa-d3c48f645be6",
+                  "label": "Other"
+                }
+              ]
+            },
+            "validations": {
+              "required": true
+            },
+            "type": "multiple_choice"
+          },
+          {
+            "id": "J3KCFWTTFsSQ",
+            "title": "What is the primary reason for seeking care today?",
+            "ref": "7bb28e91-cbf3-45ea-bc62-9a8cec52399f",
+            "properties": {},
+            "validations": {
+              "required": false
+            },
+            "type": "long_text"
+          }
+        ]
+      },
+      "type": "group"
+    },
+    {
+      "id": "74O3RUGQ8IDj",
+      "title": "Urinary / Bladder Concerns",
+      "ref": "39e42d7d-f1cf-472f-a331-6d984894ef72",
+      "properties": {
+        "button_text": "Continue",
+        "show_button": false,
+        "fields": [
+          {
+            "id": "bkbc96FpyBqP",
+            "title": "Are you having any of the following more severe symptoms? ",
+            "ref": "6d5cdef8-c458-4682-ac41-eb227837dc6d",
+            "properties": {
+              "randomize": false,
+              "allow_multiple_selection": true,
+              "allow_other_choice": false,
+              "vertical_alignment": true,
+              "choices": [
+                {
+                  "id": "YcvxOzjTHKAj",
+                  "ref": "740b6c5a-8493-4553-a95a-7940ae41535e",
+                  "label": "Severe low back or \"flank\" pain"
+                },
+                {
+                  "id": "VPF6ugsZp6JL",
+                  "ref": "9a358a26-2735-435f-bec1-190e3ea06b95",
+                  "label": "Fever greater than 100.4F"
+                },
+                {
+                  "id": "YfN0gpGQLRHP",
+                  "ref": "96a9f0ba-f89b-4db2-9863-a1d05d87265c",
+                  "label": "Vomiting and/or frequent diarrhea"
+                },
+                {
+                  "id": "agvANDFf8YeK",
+                  "ref": "fe520d61-30e8-424e-b6ef-8d75ac94e4c2",
+                  "label": "Inability to drink fluids or keep them down"
+                },
+                {
+                  "id": "gxnoU4WdGc64",
+                  "ref": "86afef2f-3140-48b4-ba01-4d24b3550661",
+                  "label": "Unable to urinate within the last 6-8 hours"
+                },
+                {
+                  "id": "u0XMSeYQHS84",
+                  "ref": "1cd23151-3018-4ac6-9a37-b092eaeca7af",
+                  "label": "None of the above; no severe \"red flag\" symptoms"
+                }
+              ]
+            },
+            "validations": {
+              "required": true
+            },
+            "type": "multiple_choice"
+          },
+          {
+            "id": "Hnnk7IN87SPQ",
+            "title": "When did the bladder (urinary) symptoms begin?",
+            "ref": "253eee94-bf8d-4ada-9e65-bf26c4cb5525",
+            "properties": {
+              "randomize": false,
+              "allow_multiple_selection": false,
+              "allow_other_choice": false,
+              "vertical_alignment": true,
+              "choices": [
+                {
+                  "id": "q7LcaD9zYXvR",
+                  "ref": "85416192-9a0b-49c8-a2df-a2e2d63230e6",
+                  "label": "Today"
+                },
+                {
+                  "id": "GgXCFpkQoatC",
+                  "ref": "1f01e86b-2686-499b-b8ab-47b8b1e14a67",
+                  "label": "Yesterday"
+                },
+                {
+                  "id": "e8wBNuLJj9aI",
+                  "ref": "6b50cb45-e0d8-43ba-b897-5559b4a28c6e",
+                  "label": "2-9 days ago"
+                },
+                {
+                  "id": "SwtLZuTE8ZQZ",
+                  "ref": "2080a922-bcca-483a-b806-5208893373a8",
+                  "label": "10-14 days ago"
+                },
+                {
+                  "id": "wPO3Idsqb6Su",
+                  "ref": "eea65e02-98d0-48d0-871a-7ed401069177",
+                  "label": "Longer than 2 weeks"
+                }
+              ]
+            },
+            "validations": {
+              "required": false
+            },
+            "type": "multiple_choice"
+          },
+          {
+            "id": "IZh8typnhkAf",
+            "title": "Are you experiencing any of the following symptoms?",
+            "ref": "fa1fe3cc-3270-4141-8d84-00b7c75075a2",
+            "properties": {
+              "randomize": false,
+              "allow_multiple_selection": true,
+              "allow_other_choice": false,
+              "vertical_alignment": true,
+              "choices": [
+                {
+                  "id": "deUFoFPGxA7c",
+                  "ref": "34a9f783-d9bb-463f-af2e-6f305e1ccdfc",
+                  "label": "Urinating more often than you usually do"
+                },
+                {
+                  "id": "OVgsSZVZc5il",
+                  "ref": "37db7dd0-2056-4929-80fc-325564955605",
+                  "label": "Pain, burning or discomfort when urinating"
+                },
+                {
+                  "id": "Tcj44U87h9uG",
+                  "ref": "661de3bc-6e12-4a83-99e3-7714ac7d5aca",
+                  "label": "Feeling like you need to urinate more urgently"
+                },
+                {
+                  "id": "Rs9Nnx2RUhlk",
+                  "ref": "06b43ded-a708-46ae-9114-bdb494beb701",
+                  "label": "Needing to wake up and urinate during the night more often than your norm"
+                },
+                {
+                  "id": "iz2uo1zNK0iS",
+                  "ref": "31faf987-1362-4a35-b185-58f05dd8a566",
+                  "label": "Pink-tinged urine or visible blood in urine"
+                },
+                {
+                  "id": "Uj5VdRw4ubyT",
+                  "ref": "23c40159-d782-4180-847a-d212f058153b",
+                  "label": "None of the above; no burning with urination, increased frequency and/or changes in urine appearance"
+                }
+              ]
+            },
+            "validations": {
+              "required": true
+            },
+            "type": "multiple_choice"
+          },
+          {
+            "id": "XcQpvS14IRZc",
+            "title": "Are you experiencing any of these other symptoms?",
+            "ref": "c4cbe655-3bdc-4c1b-8b4c-b37b67141b89",
+            "properties": {
+              "randomize": false,
+              "allow_multiple_selection": true,
+              "allow_other_choice": false,
+              "vertical_alignment": true,
+              "choices": [
+                {
+                  "id": "rPEe2l4PAbIK",
+                  "ref": "52bd96ea-a32f-46b5-846c-5c0fcffdbbb5",
+                  "label": "Genital sores"
+                },
+                {
+                  "id": "7jBAz1muO1hb",
+                  "ref": "a7328921-f6e3-4c0e-9e54-6d19fa8e32da",
+                  "label": "Abnormal vaginal or penile discharge"
+                },
+                {
+                  "id": "jhrET6ZvolJ3",
+                  "ref": "d0f26c2f-f9c9-44e3-b0f9-c4112854c7ca",
+                  "label": "New sexual partner within the last six months"
+                },
+                {
+                  "id": "iQfbGRXewNVO",
+                  "ref": "e4c7fde4-cedd-4ada-b783-99dc3116c5ff",
+                  "label": "Concerns about exposure to sexually transmitted infection"
+                },
+                {
+                  "id": "eilRCcumzjWi",
+                  "ref": "51a82a63-01bf-462f-876f-fb8f08e1525b",
+                  "label": "None of the above; no genital or STI concerns"
+                }
+              ]
+            },
+            "validations": {
+              "required": true
+            },
+            "type": "multiple_choice"
+          }
+        ]
+      },
+      "type": "group"
+    },
+    {
+      "id": "qoSvwJve0bNt",
+      "title": "Eye Concerns",
+      "ref": "b21b8f50-bc40-4f70-adcd-8477eae9c2da",
+      "properties": {
+        "button_text": "Continue",
+        "show_button": false,
+        "fields": [
+          {
+            "id": "taEujQuPb7DW",
+            "title": "When you are all done with the questions please upload a picture of the eye(s) of concern into the \"Documents\" section of the Specialty Healthcare app.  ",
+            "ref": "fa492748-9b26-4f30-b342-ab5a7926c21e",
+            "properties": {
+              "description": "It is best to get an up-close photo of the eye(s) and also one of the whole face if possible.",
+              "button_text": "Continue",
+              "hide_marks": false
+            },
+            "type": "statement"
+          },
+          {
+            "id": "tCGbWTRcK0Mz",
+            "title": "Which eye(s) is/are affected? ",
+            "ref": "5bd9d76e-7577-4138-b81a-df4c4abb12d8",
+            "properties": {
+              "randomize": false,
+              "allow_multiple_selection": false,
+              "allow_other_choice": false,
+              "vertical_alignment": true,
+              "choices": [
+                {
+                  "id": "DfxaquBia5nb",
+                  "ref": "00e3b2a3-8cf6-4234-9b7a-0141a28efdc2",
+                  "label": "Right"
+                },
+                {
+                  "id": "hWawyd62lge6",
+                  "ref": "4412e8f3-9bf5-42cf-ae7a-8c1707dd9bd7",
+                  "label": "Left"
+                },
+                {
+                  "id": "E7uvjGHvhN7o",
+                  "ref": "88611434-d294-4599-946f-6e86e1788348",
+                  "label": "Both"
+                }
+              ]
+            },
+            "validations": {
+              "required": true
+            },
+            "type": "multiple_choice"
+          },
+          {
+            "id": "BsGO4Ir5xcy1",
+            "title": "When did the eye(s) symptom(s) start?",
+            "ref": "0e66feac-4ef9-4b17-a729-d528862b7324",
+            "properties": {
+              "randomize": false,
+              "allow_multiple_selection": false,
+              "allow_other_choice": false,
+              "vertical_alignment": true,
+              "choices": [
+                {
+                  "id": "NtnawB0cSHAX",
+                  "ref": "f6d5a729-fb50-446b-8c9c-e6757ab2a092",
+                  "label": "Today"
+                },
+                {
+                  "id": "GzqGS41Wd4mN",
+                  "ref": "d930acb0-a615-4276-a298-e0493ecfbb46",
+                  "label": "Yesterday"
+                },
+                {
+                  "id": "ImvZlTodtciP",
+                  "ref": "7eeffd6f-de09-4657-b282-656689700d0e",
+                  "label": "2-3 days ago"
+                },
+                {
+                  "id": "QNw0GY4cDDNG",
+                  "ref": "2bdae8b9-fcec-4aaf-8b53-dca42ae3bd29",
+                  "label": "4-7 days ago"
+                },
+                {
+                  "id": "5BsSK9AtgiPX",
+                  "ref": "77d3ccd4-69b0-43b8-982b-4f74f3d984df",
+                  "label": "1-2 weeks ago"
+                },
+                {
+                  "id": "veWtJduJFB3h",
+                  "ref": "35df71bc-4b66-4b28-b897-af416f7782a0",
+                  "label": "Longer than 2 weeks"
+                }
+              ]
+            },
+            "validations": {
+              "required": false
+            },
+            "type": "multiple_choice"
+          },
+          {
+            "id": "TSGdjHGq44pN",
+            "title": "Choose the best description of your eye(s)",
+            "ref": "95242a1d-699d-4f27-b70c-9bee1db60eb4",
+            "properties": {
+              "randomize": false,
+              "allow_multiple_selection": false,
+              "allow_other_choice": false,
+              "vertical_alignment": true,
+              "choices": [
+                {
+                  "id": "T16IbheH6oQX",
+                  "ref": "0d106acf-f52d-444d-8465-8ae1f5e48b99",
+                  "label": "I am having no pain in my eye(s)"
+                },
+                {
+                  "id": "gQga1WNXOFLN",
+                  "ref": "ebf1b1d3-7681-4d98-9c5a-fce4c38fe7cc",
+                  "label": "I am having irritation but not actual pain in my eye(s)"
+                },
+                {
+                  "id": "nR5K4NuhtrfN",
+                  "ref": "cc5ef671-2836-4f2f-97fe-bf911bc113ed",
+                  "label": "I am having mild pain in my eye(s)"
+                },
+                {
+                  "id": "oTPXmgt24LoV",
+                  "ref": "9d8010ac-8e78-412c-bc54-5bd721427436",
+                  "label": "I am having moderate pain in my eye(s)"
+                },
+                {
+                  "id": "Q5QnU7aKxoJ3",
+                  "ref": "b9df0771-112a-443d-a261-784094f1e027",
+                  "label": "I am having severe pain in my eye(s)"
+                }
+              ]
+            },
+            "validations": {
+              "required": true
+            },
+            "type": "multiple_choice"
+          },
+          {
+            "id": "v0Qcq635FH5b",
+            "title": "How would you describe your vision?",
+            "ref": "0b09d52e-74e0-4761-8624-5319256f9386",
+            "properties": {
+              "randomize": false,
+              "allow_multiple_selection": false,
+              "allow_other_choice": false,
+              "vertical_alignment": true,
+              "choices": [
+                {
+                  "id": "Kz8gsY4ufWyW",
+                  "ref": "ba512901-1267-469e-9f6a-bf108ed4bbd2",
+                  "label": "Normal"
+                },
+                {
+                  "id": "nmSlkKq5DxUE",
+                  "ref": "276df1b7-33f6-4c50-9369-32e6b7d7fd6e",
+                  "label": "Slightly blurry but clears with blinking"
+                },
+                {
+                  "id": "u4SwY9ASW3ff",
+                  "ref": "59bae52a-2607-4354-90cd-78ced36c1d46",
+                  "label": "Reduced vision with eye open"
+                },
+                {
+                  "id": "3rhrS9VTjzDR",
+                  "ref": "8e74e696-789f-4fd7-87ed-8f63670c7e7b",
+                  "label": "Reduced vision due to eyelid swelling"
+                },
+                {
+                  "id": "Kz5ETWUn14Ik",
+                  "ref": "3ae98dbb-a062-4600-8d10-262101554c23",
+                  "label": "Can't determine due to patient's age"
+                }
+              ]
+            },
+            "validations": {
+              "required": true
+            },
+            "type": "multiple_choice"
+          },
+          {
+            "id": "SaZY7fSN4tXh",
+            "title": "Do lights bother your eye(s) much more than normal?",
+            "ref": "b9f53bf8-ca0f-47fd-9c86-2a7387e5f77d",
+            "properties": {},
+            "validations": {
+              "required": false
+            },
+            "type": "yes_no"
+          },
+          {
+            "id": "qbkja1eC4ps8",
+            "title": "Is there any eyelid swelling? ",
+            "ref": "2d5a88f9-dac1-4e8f-b2ce-a931157a8e20",
+            "properties": {},
+            "validations": {
+              "required": true
+            },
+            "type": "yes_no"
+          },
+          {
+            "id": "esrBq1AsTKdr",
+            "title": "Are you having any drainage out of your eye(s)?",
+            "ref": "e390fcb0-7770-4ce7-b36b-53507f6319cd",
+            "properties": {},
+            "validations": {
+              "required": true
+            },
+            "type": "yes_no"
+          },
+          {
+            "id": "3RoOzvgC9OSx",
+            "title": "Have you been experiencing any of these other symptoms? ",
+            "ref": "accaed1d-ad66-45bc-94d2-b6826f5da3f7",
+            "properties": {
+              "randomize": false,
+              "allow_multiple_selection": true,
+              "allow_other_choice": false,
+              "vertical_alignment": true,
+              "choices": [
+                {
+                  "id": "n4YB4qiAMPh1",
+                  "ref": "f885aa9e-f343-4e83-a797-b26d1f914dcc",
+                  "label": "Fever (temperature of 100.4F or higher)"
+                },
+                {
+                  "id": "S944p8IU4556",
+                  "ref": "bf6ca16c-aef5-41ce-a68f-305da2f889a6",
+                  "label": "Cough"
+                },
+                {
+                  "id": "XYSkbfkHnYjs",
+                  "ref": "e63da39b-e549-4c35-99f4-37cb80d8bf0c",
+                  "label": "Runny nose"
+                },
+                {
+                  "id": "7KR2qS0UC1VB",
+                  "ref": "11c37bfc-a8e0-4f09-832e-2aabf36acb7c",
+                  "label": "Eye itching"
+                },
+                {
+                  "id": "AS3wdwvL607V",
+                  "ref": "57d2d7e4-883f-4f0c-aeb8-bbd0fb4abe6e",
+                  "label": "Sore throat"
+                },
+                {
+                  "id": "4qj18Sfuy4pG",
+                  "ref": "13b4df5b-d014-4147-9f92-960003147418",
+                  "label": "Ear pain"
+                },
+                {
+                  "id": "uHrbF8VxGO4I",
+                  "ref": "1ff13c8e-a3a1-4d12-9956-b2f3bd79319b",
+                  "label": "None of the above; no fever or other cold/flu symptoms"
+                }
+              ]
+            },
+            "validations": {
+              "required": false
+            },
+            "type": "multiple_choice"
+          }
+        ]
+      },
+      "type": "group"
+    },
+    {
+      "id": "mrKGqIfz6tTo",
+      "title": "Respiratory, ENT \u0026 Allergies ",
+      "ref": "3639abd4-568c-4067-83cf-019c34538872",
+      "properties": {
+        "button_text": "Continue",
+        "show_button": false,
+        "fields": [
+          {
+            "id": "Lzigtnw76dVf",
+            "title": "When did your symptom(s) start?",
+            "ref": "95994591-a262-4206-a9c1-c8c5f3444280",
+            "properties": {
+              "randomize": false,
+              "allow_multiple_selection": false,
+              "allow_other_choice": false,
+              "vertical_alignment": true,
+              "choices": [
+                {
+                  "id": "xSxyjTGNBlLQ",
+                  "ref": "f6d5a729-fb50-446b-8c9c-e6757ab2a092",
+                  "label": "Today"
+                },
+                {
+                  "id": "Rq53x5bZSUhP",
+                  "ref": "d930acb0-a615-4276-a298-e0493ecfbb46",
+                  "label": "Yesterday"
+                },
+                {
+                  "id": "qHAmMZza0tit",
+                  "ref": "7eeffd6f-de09-4657-b282-656689700d0e",
+                  "label": "2-3 days ago"
+                },
+                {
+                  "id": "flNHZHw73DuA",
+                  "ref": "2bdae8b9-fcec-4aaf-8b53-dca42ae3bd29",
+                  "label": "4-7 days ago"
+                },
+                {
+                  "id": "byiOuGaeoXBH",
+                  "ref": "77d3ccd4-69b0-43b8-982b-4f74f3d984df",
+                  "label": "1-2 weeks ago"
+                },
+                {
+                  "id": "rYot0z2sIjfQ",
+                  "ref": "35df71bc-4b66-4b28-b897-af416f7782a0",
+                  "label": "Longer than 2 weeks"
+                },
+                {
+                  "id": "aLzAVLlSGthU",
+                  "ref": "6ab47899-8bfb-4fa7-a2bd-4467139a4a57",
+                  "label": "A month or more ago"
+                }
+              ]
+            },
+            "validations": {
+              "required": false
+            },
+            "type": "multiple_choice"
+          },
+          {
+            "id": "ue4jHUc8xYH0",
+            "title": "Are you having any of the following symptoms?",
+            "ref": "45c7e3d3-e2ac-4e2d-aea2-919cd2856fa1",
+            "properties": {
+              "randomize": false,
+              "allow_multiple_selection": true,
+              "allow_other_choice": false,
+              "vertical_alignment": true,
+              "choices": [
+                {
+                  "id": "JTSXEl6kLP2t",
+                  "ref": "45f2264f-3f9e-4619-9570-e28a695d621c",
+                  "label": "Severe headache \"the worst you've ever had\""
+                },
+                {
+                  "id": "eYzDHJQqMNLi",
+                  "ref": "b4e0a06e-2210-41f9-87d9-fb94eedcd441",
+                  "label": "Coughing up bloody mucus."
+                },
+                {
+                  "id": "WGLOHiktW2jL",
+                  "ref": "10e4e5cd-5683-4830-ae53-4e941919daa0",
+                  "label": "Moderate to severe abdominal pain"
+                },
+                {
+                  "id": "Mlc0cYMmDmdK",
+                  "ref": "aee49492-f002-460e-9111-f333ced20e69",
+                  "label": "Facial swelling"
+                },
+                {
+                  "id": "3ykSJx1qt52G",
+                  "ref": "9eed0c6d-e692-4655-8a8d-88b6476ee4c0",
+                  "label": "Change in vision"
+                },
+                {
+                  "id": "YFvNyiOpM9Ss",
+                  "ref": "ccd20e56-c89c-43ce-a9ab-ef3715959cfd",
+                  "label": "Complete loss of hearing."
+                },
+                {
+                  "id": "iXnyTBMwAZh7",
+                  "ref": "f930661b-ebb7-4c61-acac-0d0200ce68df",
+                  "label": "Chest pain"
+                },
+                {
+                  "id": "06iLuPVDJ22f",
+                  "ref": "8a8d351f-f375-4b75-b6c7-dd501772e6ad",
+                  "label": "Moderate to severe new onset shortness of breath"
+                },
+                {
+                  "id": "iZGZTdUAECtF",
+                  "ref": "dabea848-8b5e-4318-99d4-03c7f8a57f95",
+                  "label": "None of the above; No severe \"red flag\" symptoms"
+                }
+              ]
+            },
+            "validations": {
+              "required": true
+            },
+            "type": "multiple_choice"
+          },
+          {
+            "id": "x0SWqzw1HJYX",
+            "title": "Please select from the following regarding fever:",
+            "ref": "0b46777e-7166-4d32-bdde-71ee31fb8a20",
+            "properties": {
+              "randomize": false,
+              "allow_multiple_selection": false,
+              "allow_other_choice": false,
+              "vertical_alignment": true,
+              "choices": [
+                {
+                  "id": "gUxS8uQRsSqW",
+                  "ref": "d6afcaa8-2bbf-4c0b-91bd-43c2253ddf8c",
+                  "label": "Yes, a fever of 100.4F or higher was measured with a thermometer"
+                },
+                {
+                  "id": "tSkGUi4axyie",
+                  "ref": "1c1b2204-a63b-4c53-ac3c-839c867e6d33",
+                  "label": "Yes, a temperature of less than 100.4 was measured with a thermometer"
+                },
+                {
+                  "id": "ZgCAjRSJzfKz",
+                  "ref": "b516396f-f50a-4fc0-90b8-90ddccc4f2cd",
+                  "label": "No thermometer used but definitely felt warm to touch"
+                },
+                {
+                  "id": "vZ7afwsLDWQx",
+                  "ref": "8337d5c1-29d2-4103-a2fe-c5b19cacff6a",
+                  "label": "Had a fever but it is gone now"
+                },
+                {
+                  "id": "f13yAn09LMrk",
+                  "ref": "15e5ed85-e152-4cf3-bb1c-ee134d94ae9f",
+                  "label": "Have not had a fever throughout this illness"
+                }
+              ]
+            },
+            "validations": {
+              "required": true
+            },
+            "type": "multiple_choice"
+          },
+          {
+            "id": "mOfNBiiNhH5K",
+            "title": "What was the measured temperature?",
+            "ref": "3f3bba87-b210-43c0-bb79-b19a889f7899",
+            "properties": {
+              "description": "In Farenheit like 101.1F"
+            },
+            "validations": {
+              "required": false
+            },
+            "type": "short_text"
+          },
+          {
+            "id": "6AvP5Eq6M4Cn",
+            "title": "Are you experiencing a cough?",
+            "ref": "527c054c-6f32-4c81-aa5e-23411da3682d",
+            "properties": {},
+            "validations": {
+              "required": true
+            },
+            "type": "yes_no"
+          },
+          {
+            "id": "fRytEdK51TQL",
+            "title": "Are you experiencing any wheezing?",
+            "ref": "6cd0c492-550e-4265-a282-a15128988969",
+            "properties": {},
+            "validations": {
+              "required": false
+            },
+            "type": "yes_no"
+          },
+          {
+            "id": "Uwj4Kcne22NP",
+            "title": "Are you noticing any shortness of breath?",
+            "ref": "371ccee2-c490-4b87-a435-814ca6daed79",
+            "properties": {},
+            "validations": {
+              "required": false
+            },
+            "type": "yes_no"
+          },
+          {
+            "id": "37578ZYdWnXm",
+            "title": "What best describes the shortness of breath?",
+            "ref": "381198f4-0c79-4289-bf68-a3c55352baae",
+            "properties": {
+              "randomize": false,
+              "allow_multiple_selection": false,
+              "allow_other_choice": false,
+              "vertical_alignment": true,
+              "choices": [
+                {
+                  "id": "DKxvdf6t4QVh",
+                  "ref": "09bf92c3-cda2-4e2d-9b40-49f4232fdd36",
+                  "label": "Mild to moderate shortness of breath with moderate activity like working out or going up stairs"
+                },
+                {
+                  "id": "WlLgT19retYK",
+                  "ref": "7a2a5b6b-21e1-4a2b-8e49-10239ce6518f",
+                  "label": "Mild to moderate shortness of breath with regular daily activities like slow walking, getting dressed, etc."
+                },
+                {
+                  "id": "F5JbvJPDR84s",
+                  "ref": "32a6a8e5-0664-44cc-879e-caa71c9e7018",
+                  "label": "Mild to moderate shortness of breath at rest"
+                }
+              ]
+            },
+            "validations": {
+              "required": false
+            },
+            "type": "multiple_choice"
+          },
+          {
+            "id": "WOi5BrtE0cn0",
+            "title": "Do you have Ear Pain?",
+            "ref": "9e625f22-ee19-4492-9897-97e8375258fb",
+            "properties": {},
+            "validations": {
+              "required": true
+            },
+            "type": "yes_no"
+          },
+          {
+            "id": "GRUgSxTXTRnG",
+            "title": "Which ear is having pain?",
+            "ref": "82c36b8e-e4ed-4b1c-81b1-f0ece0b53865",
+            "properties": {
+              "randomize": false,
+              "allow_multiple_selection": false,
+              "allow_other_choice": false,
+              "vertical_alignment": true,
+              "choices": [
+                {
+                  "id": "Se5iEsbtF8sa",
+                  "ref": "857efad6-fd5f-4cef-aef7-a5515629f44e",
+                  "label": "Right only"
+                },
+                {
+                  "id": "h4rvkh5ljNeJ",
+                  "ref": "3c376ca1-2ff2-4e3c-b018-78736c3a94d5",
+                  "label": "Left only"
+                },
+                {
+                  "id": "mvaE9gs5IOwP",
+                  "ref": "ca5c1351-127e-4164-adc1-bb9f0a086881",
+                  "label": "Both ears"
+                }
+              ]
+            },
+            "validations": {
+              "required": false
+            },
+            "type": "multiple_choice"
+          },
+          {
+            "id": "frlqvCas5jrt",
+            "title": "Do you have a history of seasonal allergies (hay fever) or suspect you have them?",
+            "ref": "76aea2fa-cba3-400a-b0d8-485416241861",
+            "properties": {},
+            "validations": {
+              "required": false
+            },
+            "type": "yes_no"
+          },
+          {
+            "id": "nKnIBJ4Xrs8v",
+            "title": "Any Sinus or Nasal symptoms?",
+            "ref": "d7f05a87-e981-403b-8113-ddba96ad4160",
+            "properties": {},
+            "validations": {
+              "required": true
+            },
+            "type": "yes_no"
+          },
+          {
+            "id": "Osc9qvOJZhTj",
+            "title": "Which of the following sinus symptoms are you having?",
+            "ref": "58af010f-e909-49c2-a4ed-8497364593b8",
+            "properties": {
+              "randomize": false,
+              "allow_multiple_selection": true,
+              "allow_other_choice": false,
+              "vertical_alignment": true,
+              "choices": [
+                {
+                  "id": "fP3p5v9pENul",
+                  "ref": "2ed68a58-4987-4c31-b802-90573eb993bb",
+                  "label": "clear, thin runny drainage"
+                },
+                {
+                  "id": "G3KsLJzIN9nK",
+                  "ref": "fd2a312f-88ea-4f12-9f8d-2eec55e2fc03",
+                  "label": "thick, colored drainage"
+                },
+                {
+                  "id": "2BAlj75uzIaI",
+                  "ref": "2fe798c7-a9df-44a1-9057-79d17c6165bd",
+                  "label": "one or both nostrils are blocked/clogged"
+                },
+                {
+                  "id": "sQypzLkgNNQj",
+                  "ref": "1ea8a9c6-2ac9-4c38-91b6-190831f1fc04",
+                  "label": "sense of smell is affected"
+                },
+                {
+                  "id": "vg9tfrl03lmj",
+                  "ref": "01001df6-a99a-45b5-b97b-1fa9bcc12379",
+                  "label": "pain in the sinuses (often cheekbones and/or forehead area)"
+                },
+                {
+                  "id": "NMkMXDweVquH",
+                  "ref": "be02ef03-8ed8-4b85-be81-841c7bf1dd45",
+                  "label": "pain in the jaw or tooth region"
+                },
+                {
+                  "id": "Ri0iP0NsL4Nu",
+                  "ref": "046da2c9-932d-40d6-bbe6-9ace7782fc41",
+                  "label": "None of the above"
+                },
+                {
+                  "id": "LqBnx3iwXjvB",
+                  "ref": "b68731e6-bfbd-4588-bf69-57458eb9ec4c",
+                  "label": "Other"
+                }
+              ]
+            },
+            "validations": {
+              "required": true
+            },
+            "type": "multiple_choice"
+          },
+          {
+            "id": "4QPA1MTTbA8d",
+            "title": "Please share more details:",
+            "ref": "1d2f2106-0c46-46cc-ae52-e599c9d2f511",
+            "properties": {},
+            "validations": {
+              "required": false
+            },
+            "type": "short_text"
+          },
+          {
+            "id": "kQbbsRS8ajk9",
+            "title": "Do you have throat pain or discomfort?",
+            "ref": "58d9fbe4-7e9f-4da9-aafc-f3b36e747533",
+            "properties": {},
+            "validations": {
+              "required": true
+            },
+            "type": "yes_no"
+          },
+          {
+            "id": "VL630ltkz92q",
+            "title": "Are there any eye symptoms?",
+            "ref": "a0c4a70d-17bf-40e8-a0a2-9e4be165177f",
+            "properties": {},
+            "validations": {
+              "required": true
+            },
+            "type": "yes_no"
+          },
+          {
+            "id": "dTvEtKfkb9ZQ",
+            "title": " Which of following eye symptoms are being experienced?",
+            "ref": "657aa9f8-04df-42b5-ad40-e410e31149f4",
+            "properties": {
+              "randomize": false,
+              "allow_multiple_selection": true,
+              "allow_other_choice": false,
+              "vertical_alignment": true,
+              "choices": [
+                {
+                  "id": "HKj4oI9NMDsj",
+                  "ref": "2a7bfb1b-ba72-457b-91d6-95a55ac806ae",
+                  "label": "Crusting, especially in the morning"
+                },
+                {
+                  "id": "DZn94xKRKtIV",
+                  "ref": "4221bc83-419c-45b4-a473-2043482a1b00",
+                  "label": "Thick, goopy drainage off and on all day"
+                },
+                {
+                  "id": "LKFsS8ijALKa",
+                  "ref": "8a126fc9-6b30-4c1f-b70e-097543aeb991",
+                  "label": "Redness of the eye"
+                },
+                {
+                  "id": "SHqTy5SjKvjv",
+                  "ref": "4dec46f1-eb10-44f5-8b7a-8c01b3e86405",
+                  "label": "Itching"
+                },
+                {
+                  "id": "B9k2e3BMYu62",
+                  "ref": "a8da00e8-ffb8-4215-975e-79ac26e0e158",
+                  "label": "Mild irritation"
+                },
+                {
+                  "id": "JQFvLMDnabhr",
+                  "ref": "be9f5003-22d0-4c25-a19f-36886d695ec8",
+                  "label": "Mild swelling"
+                },
+                {
+                  "id": "Uvms9MRtn1GA",
+                  "ref": "4020654e-c218-4e1a-a8d7-34261be0f2f9",
+                  "label": "Involves one eye only"
+                },
+                {
+                  "id": "FVQtUZxj0LBT",
+                  "ref": "de63956b-dbd4-4ea7-9caf-4a4b5e07504e",
+                  "label": "Involves both eyes"
+                },
+                {
+                  "id": "egY0FeXtUufP",
+                  "ref": "30736abf-3f93-4a95-ba99-0f69e1aab529",
+                  "label": "Other"
+                }
+              ]
+            },
+            "validations": {
+              "required": false
+            },
+            "type": "multiple_choice"
+          },
+          {
+            "id": "1RPEWiNovp7I",
+            "title": "Please share more details:",
+            "ref": "fa2f6cf9-13ff-4c73-9f29-40a0b986f3b8",
+            "properties": {},
+            "validations": {
+              "required": false
+            },
+            "type": "short_text"
+          }
+        ]
+      },
+      "type": "group"
+    },
+    {
+      "id": "0Fx4VbpclFuQ",
+      "title": "Dermatology",
+      "ref": "5cbdac4f-429e-42f7-97ed-f7ba497d0d23",
+      "properties": {
+        "button_text": "Continue",
+        "show_button": true,
+        "fields": [
+          {
+            "id": "KPI0jMsXGMNu",
+            "title": "When you are finished with the entire process please log into your Specialty Healthcare app, go to the \"Documents\" area and upload photos of your skin concern.",
+            "ref": "20f60f31-dff2-4cc1-9a17-88e4a4f2df1a",
+            "properties": {
+              "button_text": "Continue",
+              "hide_marks": false
+            },
+            "type": "statement"
+          },
+          {
+            "id": "ARzmlxGIzHjZ",
+            "title": "Do you have any of the following?",
+            "ref": "f22b14e2-c4f7-46ba-aef8-0721c5b40258",
+            "properties": {
+              "randomize": false,
+              "allow_multiple_selection": true,
+              "allow_other_choice": false,
+              "vertical_alignment": true,
+              "choices": [
+                {
+                  "id": "Iko5czFnfjC9",
+                  "ref": "787fb804-4b32-4522-98c3-7f4aebf9e57b",
+                  "label": "High fever (measured at 103F or higher)"
+                },
+                {
+                  "id": "OGX1xIPR1fYf",
+                  "ref": "2b618d20-e314-4500-bdc8-d49326deaa58",
+                  "label": "Severe blistering or skin sloughing off"
+                },
+                {
+                  "id": "2TbMLhp2jzdW",
+                  "ref": "962fcb2d-ffa9-41dd-b6d5-a35a5021defe",
+                  "label": "Fever and inconsolability or extreme irritability"
+                },
+                {
+                  "id": "DoGJiDvL3M4k",
+                  "ref": "8529a339-a95c-4cb8-8c97-2047c537ebe8",
+                  "label": "Fever and tick exposure, especially with rash"
+                },
+                {
+                  "id": "q4dCttC2GP8N",
+                  "ref": "af99030e-4f00-46e6-964a-ee001ca0bc44",
+                  "label": "Strawberry-looking tongue"
+                },
+                {
+                  "id": "bqiNd3GZVjZ8",
+                  "ref": "9a8706b7-e744-4fde-8d2c-47e60fda7454",
+                  "label": "New onset shortness of breath"
+                },
+                {
+                  "id": "sWdeLYqEaYEB",
+                  "ref": "c858f43f-e8af-4b4c-9e50-13dfa37be96d",
+                  "label": "Conjunctival inflammation"
+                },
+                {
+                  "id": "HqvO0hZ7gY6i",
+                  "ref": "472f010e-b0c7-43e5-9a07-b0d2ef22d002",
+                  "label": "Bloody diarrhea"
+                },
+                {
+                  "id": "CjApPFsJdug0",
+                  "ref": "5b716917-00e4-448e-bb57-8b0a12d7078d",
+                  "label": "Stiff neck with a fever"
+                },
+                {
+                  "id": "hVSpVeEnJaHH",
+                  "ref": "c11d5e49-ed8a-4159-bd66-5d27977193ad",
+                  "label": "Known exposure to a communicable disease"
+                },
+                {
+                  "id": "Dpi1oD2KabSz",
+                  "ref": "213a52cb-1ef4-40a2-8e71-71d2894b866c",
+                  "label": "None of the above; no severe \"red flag\" symptoms or exposures"
+                }
+              ]
+            },
+            "validations": {
+              "required": true
+            },
+            "type": "multiple_choice"
+          },
+          {
+            "id": "QhEwY2GO3I52",
+            "title": "When did your skin concern start?",
+            "ref": "e14964f1-8f9d-48c4-9fd7-a35319995a82",
+            "properties": {
+              "randomize": false,
+              "allow_multiple_selection": false,
+              "allow_other_choice": false,
+              "vertical_alignment": true,
+              "choices": [
+                {
+                  "id": "HWEFA1THDPv3",
+                  "ref": "5fc5bdd4-fc2c-4d1e-bae9-f32b466e3aff",
+                  "label": "Today"
+                },
+                {
+                  "id": "Gj0p3K3T2y5H",
+                  "ref": "f05a3998-74d9-4d2f-a067-12334b6abfcf",
+                  "label": "1-2 days ago"
+                },
+                {
+                  "id": "tdF34dKjk1uj",
+                  "ref": "499fb1a1-a7f0-45e8-ac5a-480078243a9e",
+                  "label": "3-6 days ago"
+                },
+                {
+                  "id": "44KCbru8NDSZ",
+                  "ref": "f6066955-063f-479a-9040-88919056ead8",
+                  "label": "1-2 weeks ago"
+                },
+                {
+                  "id": "XdjkW9LA4KN4",
+                  "ref": "4a1df60d-4a25-4701-849d-fa12b86cb744",
+                  "label": "2-4 weeks ago"
+                },
+                {
+                  "id": "Cy4dFI0BfvuI",
+                  "ref": "e7301349-2027-44f6-8087-4c5da053a3e1",
+                  "label": "Greater than 1 month ago"
+                }
+              ]
+            },
+            "validations": {
+              "required": false
+            },
+            "type": "multiple_choice"
+          },
+          {
+            "id": "YrfMsTnw9ZQU",
+            "title": "Please share the location on your body of the skin concern",
+            "ref": "b1724b43-91d9-47e4-80e3-02cf5d17cd90",
+            "properties": {
+              "description": "For example \"right upper arm\""
+            },
+            "validations": {
+              "required": false
+            },
+            "type": "short_text"
+          },
+          {
+            "id": "xNh8TY4xRTbR",
+            "title": "Which of the following apply to your skin concern?",
+            "ref": "29c950ea-e45e-4838-a07b-3b640095c940",
+            "properties": {
+              "randomize": false,
+              "allow_multiple_selection": true,
+              "allow_other_choice": false,
+              "vertical_alignment": true,
+              "choices": [
+                {
+                  "id": "JKef8MoQcq6T",
+                  "ref": "4ced3f3e-8323-44e8-979f-ed59a2178b5c",
+                  "label": "Redness"
+                },
+                {
+                  "id": "dRy7zreYPXQn",
+                  "ref": "c103592c-bf6e-4be1-9010-3a575ef762fe",
+                  "label": "Itching"
+                },
+                {
+                  "id": "urlHxhWQ3gZd",
+                  "ref": "76f1034b-2100-4729-bd89-a0b82d9c2a6f",
+                  "label": "Irritation"
+                },
+                {
+                  "id": "nfXcg2fUmFEp",
+                  "ref": "9310c020-b6ef-450f-bdc7-ee14d559f4a1",
+                  "label": "Bumps (not fluid filled)"
+                },
+                {
+                  "id": "kz4VhQuCLd0n",
+                  "ref": "9ad3e3bb-1594-4123-bcda-d5aeed0aed7e",
+                  "label": "Bumps (fluid filled)"
+                },
+                {
+                  "id": "jt3zgCbJ5cRP",
+                  "ref": "6e3ac720-842e-4781-a803-d4eeaf78de9c",
+                  "label": "Flaking of the skin"
+                },
+                {
+                  "id": "Q7tdDfBmdwF3",
+                  "ref": "68656843-f31b-4abf-a72a-ece6478ec419",
+                  "label": "Circular or ring-like rash"
+                },
+                {
+                  "id": "EzeFIwIhvo8Q",
+                  "ref": "d4bd1ee8-90b7-49d5-b9ea-1e15d6c86445",
+                  "label": "Burning"
+                },
+                {
+                  "id": "FftG1AhJPkCe",
+                  "ref": "7272a3c9-9f83-4794-b309-fcab7f1ff2a5",
+                  "label": "Swelling"
+                },
+                {
+                  "id": "38R8lH68tC7h",
+                  "ref": "2dec8fc2-2e81-44cf-92e1-b8d1b38fec93",
+                  "label": "Drainage or oozing"
+                },
+                {
+                  "id": "1vEQMLZlsfUO",
+                  "ref": "3cce3d48-cc5d-4c68-83c3-eec5456a16e4",
+                  "label": "Other"
+                }
+              ]
+            },
+            "validations": {
+              "required": true
+            },
+            "type": "multiple_choice"
+          },
+          {
+            "id": "5dskzL9dyTx3",
+            "title": "Please share more details:",
+            "ref": "3bdc4355-214a-4c3e-9220-e49cb136845c",
+            "properties": {},
+            "validations": {
+              "required": false
+            },
+            "type": "short_text"
+          }
+        ]
+      },
+      "type": "group"
+    },
+    {
+      "id": "ElHvJTZ0WHbk",
+      "title": "Vaginitis",
+      "ref": "386cc5ad-d6e4-49df-b8f0-f16eb7e6fb07",
+      "properties": {
+        "button_text": "Continue",
+        "show_button": true,
+        "fields": [
+          {
+            "id": "NtGoNDYjDepc",
+            "title": "Are you experiencing vaginal itching symptoms:",
+            "ref": "343e8755-c903-42ef-beb5-ad88b5946351",
+            "properties": {
+              "randomize": false,
+              "allow_multiple_selection": true,
+              "allow_other_choice": false,
+              "vertical_alignment": true,
+              "choices": [
+                {
+                  "id": "VGWYYt3I5bQa",
+                  "ref": "f0f16079-78c5-4b8e-91bd-9c2e45376fae",
+                  "label": "No itching"
+                },
+                {
+                  "id": "a8q53XanDeV1",
+                  "ref": "4be6cb8c-0b48-4f50-ad65-f292ec9f0625",
+                  "label": "Itching inside the vagina"
+                },
+                {
+                  "id": "yONOZ237dJzN",
+                  "ref": "e476a9df-d8b3-46bc-99d2-776e6a4dd8a7",
+                  "label": "Itching on the outside or surrounding areas of the vagina"
+                },
+                {
+                  "id": "pDOWRRfnwTNp",
+                  "ref": "424d24a2-7ef6-4c94-8d48-8c3fe3d7d932",
+                  "label": "Other"
+                }
+              ]
+            },
+            "validations": {
+              "required": false
+            },
+            "type": "multiple_choice"
+          },
+          {
+            "id": "wb5Mtg4qpTwB",
+            "title": "Please share more details:",
+            "ref": "87285ecc-3ef2-4793-8430-6eeebb55cb54",
+            "properties": {},
+            "validations": {
+              "required": false
+            },
+            "type": "short_text"
+          },
+          {
+            "id": "1MHkuV0h3s2X",
+            "title": "Any changes in vaginal discharge?",
+            "ref": "1df0d0e0-12a0-4bac-b041-3f11f4329c63",
+            "properties": {
+              "randomize": false,
+              "allow_multiple_selection": true,
+              "allow_other_choice": false,
+              "vertical_alignment": true,
+              "choices": [
+                {
+                  "id": "mo6gHDiF3PtK",
+                  "ref": "cffbb5b5-8ea5-4691-8bcc-d12315c52f10",
+                  "label": "No abnormal or different vaginal discharge"
+                },
+                {
+                  "id": "eIPqQgwE6TlL",
+                  "ref": "97279152-cf26-4a19-8237-7aa59b22ffd4",
+                  "label": "Thick, whitish \"cottage cheese-like\" discharge"
+                },
+                {
+                  "id": "tPrLg6fuh3N8",
+                  "ref": "e0dfbaba-aa9e-440d-8883-749de626ffcf",
+                  "label": "Thin or stringy discharge"
+                },
+                {
+                  "id": "KAr9dmXmZ1Ua",
+                  "ref": "9ae00a3d-4ff9-4c7c-b7cc-461898806e55",
+                  "label": "Clear discharge"
+                },
+                {
+                  "id": "020sKnmfAa4E",
+                  "ref": "859502cf-db6d-4b48-8991-5202b70bef6c",
+                  "label": "Green or yellow discharge"
+                },
+                {
+                  "id": "ksqCoclf9jej",
+                  "ref": "13a33038-93f4-42b8-8d81-bd7d6d410f67",
+                  "label": "Brown or dark discharge"
+                },
+                {
+                  "id": "iiDvdjXesMLu",
+                  "ref": "5d6c47ca-7d1c-4253-beca-02a44cad46a4",
+                  "label": "Increased discharge than your normal"
+                },
+                {
+                  "id": "gW0NhfxH0BPI",
+                  "ref": "acbbf437-84f8-4a66-ab5a-eab769d79866",
+                  "label": "Fishy odor"
+                },
+                {
+                  "id": "39XT7Ncn7ijy",
+                  "ref": "a3609e03-d47d-4925-9af4-941db26f7c94",
+                  "label": "Other odor"
+                },
+                {
+                  "id": "dx41ajB5UZBX",
+                  "ref": "83a66cfb-db31-4958-976e-d1e3c16e9bc2",
+                  "label": "Other symptoms"
+                }
+              ]
+            },
+            "validations": {
+              "required": false
+            },
+            "type": "multiple_choice"
+          },
+          {
+            "id": "yVMPVhTZRR2o",
+            "title": "Please share more details:",
+            "ref": "8c0e00c0-22d8-4839-983e-36a589819ad7",
+            "properties": {},
+            "validations": {
+              "required": false
+            },
+            "type": "short_text"
+          },
+          {
+            "id": "Pti3vGlLqFps",
+            "title": "Are you having any vaginal pain or burning?",
+            "ref": "96b5324e-2c94-460a-90b1-d4647b6bb8f1",
+            "properties": {},
+            "validations": {
+              "required": false
+            },
+            "type": "yes_no"
+          }
+        ]
+      },
+      "type": "group"
+    },
+    {
+      "id": "2bcYMk5VOZWv",
+      "title": "Acute Symptoms",
+      "ref": "e84b098a-3f7c-4bcd-b751-bb0a9b2d1715",
+      "properties": {
+        "button_text": "Continue",
+        "show_button": false,
+        "fields": [
+          {
+            "id": "sS6vI1flUdZ2",
+            "title": "Are you having any of the following more severe symptom?",
+            "ref": "c4c6e7dc-06a2-4250-9878-3f2f30095eec",
+            "properties": {
+              "randomize": false,
+              "allow_multiple_selection": false,
+              "allow_other_choice": false,
+              "vertical_alignment": true,
+              "choices": [
+                {
+                  "id": "FraWxlPTgJcB",
+                  "ref": "d965c935-4c84-447b-b6fb-3e6624889ed2",
+                  "label": "Chest pain"
+                },
+                {
+                  "id": "7KCr44wYBkSB",
+                  "ref": "b7a0f993-7962-48da-a888-b8c1d20770cf",
+                  "label": "Moderate to severe shortness of breath"
+                },
+                {
+                  "id": "jtRmSvM1wwfR",
+                  "ref": "af266578-b94c-42a5-872e-3080e33ce985",
+                  "label": "Severe pain of any kind"
+                },
+                {
+                  "id": "XRT133QJXqRb",
+                  "ref": "b040d67b-ade7-414c-af72-7fcf1ee2daa2",
+                  "label": "Fever greater than 103F in adult or 104F in a child"
+                },
+                {
+                  "id": "aWa47te1AeVY",
+                  "ref": "a7fff16d-99f3-4c47-b39a-6b46457d4463",
+                  "label": "Sudden onset of vision loss"
+                },
+                {
+                  "id": "RrSNP7ey2owN",
+                  "ref": "63b0c28b-2d8a-44e4-ab19-b92d9baaa613",
+                  "label": "Slurred speech"
+                },
+                {
+                  "id": "1HfFcYCVED5C",
+                  "ref": "2697e7c7-e247-4bfb-b6f1-243b6bed0649",
+                  "label": "None of the above; no severe \"red flag\" symptoms"
+                }
+              ]
+            },
+            "validations": {
+              "required": false
+            },
+            "type": "multiple_choice"
+          },
+          {
+            "id": "Qzapj0LiJc9i",
+            "title": "When did this problem start?",
+            "ref": "0db38205-8925-46d0-b43c-3febaf37c666",
+            "properties": {
+              "randomize": false,
+              "allow_multiple_selection": false,
+              "allow_other_choice": false,
+              "vertical_alignment": true,
+              "choices": [
+                {
+                  "id": "VSwPDpuxTw9c",
+                  "ref": "47f1bbf8-1bc3-4bc6-bc4b-f00213ab1502",
+                  "label": "Today"
+                },
+                {
+                  "id": "DwjubC1l282i",
+                  "ref": "8c77042d-034b-44b6-9a14-89205a7b26e7",
+                  "label": "Yesterday"
+                },
+                {
+                  "id": "Uy1opew6BIpc",
+                  "ref": "20d2d887-751b-49d9-baa8-bbf86158ab77",
+                  "label": "2-3 days ago"
+                },
+                {
+                  "id": "PM8yP2CcriOg",
+                  "ref": "698d9e08-05ec-4e8c-9459-e7edf301ec86",
+                  "label": "4-7 days ago"
+                },
+                {
+                  "id": "sg1ebyWRGxhV",
+                  "ref": "0932744d-4132-4558-a618-be139570840b",
+                  "label": "1-2 weeks ago"
+                },
+                {
+                  "id": "RFgM76zR0yzc",
+                  "ref": "c5aaf701-64a8-406d-ae66-56fc32f9dd29",
+                  "label": "2-4 weeks ago"
+                },
+                {
+                  "id": "Gr5trAVIMKoV",
+                  "ref": "4e626129-8d35-4d6f-b059-2eab16139e92",
+                  "label": "1-3 months ago"
+                },
+                {
+                  "id": "AOzkMmuryFpo",
+                  "ref": "da2f6fed-3d13-4131-a82e-c7a6cc8fb345",
+                  "label": "Greater than 3 months ago"
+                }
+              ]
+            },
+            "validations": {
+              "required": false
+            },
+            "type": "multiple_choice"
+          },
+          {
+            "id": "uB0OsAXejJpb",
+            "title": "Have you tried any treatments prior to this visit? ",
+            "ref": "ae1d9d32-1296-4b52-bfb0-2e153756d551",
+            "properties": {
+              "description": "(Could be any at-home or previous medical visit; medication or non-medication therapy-you may skip if not applicable)"
+            },
+            "validations": {
+              "required": false
+            },
+            "type": "yes_no"
+          },
+          {
+            "id": "qzMsyXMEE9b5",
+            "title": "What specific treatment(s) have you tried?",
+            "ref": "f443be96-e76a-4615-af32-bcf92d5d4831",
+            "properties": {},
+            "validations": {
+              "required": false
+            },
+            "type": "short_text"
+          },
+          {
+            "id": "wHq5HTjToKvi",
+            "title": "Please share any other symptoms or information with your medical provider about your concern today:",
+            "ref": "396ddc90-a1f2-4268-b7f0-f4491331b256",
+            "properties": {
+              "description": "You may skip question if there's nothing more to share but the more details the better."
+            },
+            "validations": {
+              "required": false
+            },
+            "type": "long_text"
+          }
+        ]
+      },
+      "type": "group"
+    },
+    {
+      "id": "s7hu19KV9SwR",
+      "title": "Chronic Care Follow-up",
+      "ref": "afc9a5f8-2272-4cd0-9b3b-9114306d0ba3",
+      "properties": {
+        "button_text": "Continue",
+        "show_button": true,
+        "fields": [
+          {
+            "id": "294M6jiFRfQl",
+            "title": "What is/are your primary reason(s) for this follow-up of your chronic condition(s) visit?",
+            "ref": "d19059fc-5bf5-4033-9a2a-ea1ae86c90cf",
+            "properties": {
+              "randomize": false,
+              "allow_multiple_selection": true,
+              "allow_other_choice": false,
+              "vertical_alignment": true,
+              "choices": [
+                {
+                  "id": "EzivIGJem0Hj",
+                  "ref": "bca5c1a7-6033-404e-9b21-533c065f206d",
+                  "label": "A general check-in on your condition(s)"
+                },
+                {
+                  "id": "NdwTCof30KYH",
+                  "ref": "72960d63-8977-4297-bbdf-41a204f0a37f",
+                  "label": "A specific update or concern"
+                },
+                {
+                  "id": "vUE7ykdLxeRo",
+                  "ref": "34919a80-cf08-4539-a08e-dfb4c85ba109",
+                  "label": "Discuss labwork/bloodwork"
+                },
+                {
+                  "id": "d91hm4V68dYq",
+                  "ref": "4deb0f59-6734-49e7-9b16-0211e7cecf8d",
+                  "label": "Discuss medications (refills, concerns, etc)"
+                },
+                {
+                  "id": "JhUoEcqjIqW9",
+                  "ref": "5809b826-63ad-44c1-a52c-a3e91fd1fe49",
+                  "label": "Other"
+                }
+              ]
+            },
+            "validations": {
+              "required": false
+            },
+            "type": "multiple_choice"
+          },
+          {
+            "id": "qOk22qmRuMix",
+            "title": "Please share more details about the condition you'd like to check in on:",
+            "ref": "6ec56864-56b9-4853-b62a-19a7f089b959",
+            "properties": {},
+            "validations": {
+              "required": false
+            },
+            "type": "long_text"
+          },
+          {
+            "id": "MVDn5kFVUUIB",
+            "title": "Please share any additional updates you have for your provider:",
+            "ref": "4639aca9-0fa6-413d-8fa6-ef5854485d6e",
+            "properties": {
+              "description": "Examples include blood pressure readings, blood sugars, medication tolerance, etc. You may skip."
+            },
+            "validations": {
+              "required": false
+            },
+            "type": "long_text"
+          }
+        ]
+      },
+      "type": "group"
+    },
+    {
+      "id": "vEItiFk18RIu",
+      "title": "Initial Chronic Condition Consult",
+      "ref": "8aadb2b9-ef09-4d28-81ff-078dac1325cd",
+      "properties": {
+        "button_text": "Continue",
+        "show_button": false,
+        "fields": [
+          {
+            "id": "j08eHUfSxUOS",
+            "title": "What is/are your primary reason(s) for your chronic condition(s) visit?",
+            "ref": "90c5d894-46d7-4840-a8d2-01dda7ba430d",
+            "properties": {
+              "randomize": false,
+              "allow_multiple_selection": true,
+              "allow_other_choice": false,
+              "vertical_alignment": true,
+              "choices": [
+                {
+                  "id": "9lX4rue25oC8",
+                  "ref": "6412e4e1-061d-407b-89d0-ed0954f1f11b",
+                  "label": "A general check-in on how my condition is doing"
+                },
+                {
+                  "id": "YVEykZPXgAbo",
+                  "ref": "b72d4955-2e78-44fb-a035-2e574dab38a9",
+                  "label": "Establish care with a Specialty provider to manage your condition(s)"
+                },
+                {
+                  "id": "R4H4QgGTWfQB",
+                  "ref": "90fddbfb-b9ed-4853-9706-ac6d1c079a3a",
+                  "label": "Discuss the need for labwork"
+                },
+                {
+                  "id": "GOYvZYHUaDSF",
+                  "ref": "d6858f7f-fe69-4c95-b0d9-b4019f928dc0",
+                  "label": "Refills and/or new med prescriptions (medication management)"
+                },
+                {
+                  "id": "vlHOM4hcd1u1",
+                  "ref": "c185e937-11b5-400e-8f2c-5fa0caacaa50",
+                  "label": "Concerns related to my condition(s)"
+                },
+                {
+                  "id": "r0Ztb8nR9NG9",
+                  "ref": "5207f688-93a1-46a6-a286-0e55362aed0f",
+                  "label": "Other"
+                }
+              ]
+            },
+            "validations": {
+              "required": true
+            },
+            "type": "multiple_choice"
+          },
+          {
+            "id": "Ifexqgf2cimg",
+            "title": "Please share more details about your primary reason for needing a visit:",
+            "ref": "97a21dee-ab26-45a4-929e-ef79ef815e09",
+            "properties": {},
+            "validations": {
+              "required": false
+            },
+            "type": "short_text"
+          },
+          {
+            "id": "GDp0kVuz2nrw",
+            "title": "Next we are going to ask if you'd like to discuss certain common chronic conditions one at a time.  If they don't apply to you, simply select \"no\".",
+            "ref": "05c42c23-e501-4190-a66c-1e043a6865bd",
+            "properties": {
+              "button_text": "Continue",
+              "hide_marks": false
+            },
+            "type": "statement"
+          }
+        ]
+      },
+      "type": "group"
+    },
+    {
+      "id": "L6YXasxn64Wg",
+      "title": "Diabetes, Type 2",
+      "ref": "e0040ba3-770f-4179-a107-de35ba460a4d",
+      "properties": {
+        "button_text": "Continue",
+        "show_button": false,
+        "fields": [
+          {
+            "id": "LiPlDzn0CulU",
+            "title": "Would you like to discuss Diabetes, Type 2?",
+            "ref": "78402997-6809-4f34-90bd-7eac13159171",
+            "properties": {},
+            "validations": {
+              "required": false
+            },
+            "type": "yes_no"
+          },
+          {
+            "id": "ZWy5vvZgoqSv",
+            "title": "How old were you when first diagnosed with Type 2 Diabetes?",
+            "ref": "acedb884-d985-4b8d-a70d-8b2948409a79",
+            "properties": {},
+            "validations": {
+              "required": false
+            },
+            "type": "number"
+          },
+          {
+            "id": "psTmz1KEF1Q4",
+            "title": "How do you treat your diabetes?",
+            "ref": "4d009d19-4e29-49cb-afbd-26e1867fb631",
+            "properties": {
+              "randomize": false,
+              "allow_multiple_selection": true,
+              "allow_other_choice": false,
+              "vertical_alignment": true,
+              "choices": [
+                {
+                  "id": "M2SpALTGi5Ka",
+                  "ref": "445018aa-0395-47be-a564-9c3a443c16d4",
+                  "label": "Diet"
+                },
+                {
+                  "id": "POVzLhugN80O",
+                  "ref": "b23b7194-07df-4749-81a4-5d995ae0999a",
+                  "label": "Exercise"
+                },
+                {
+                  "id": "gerv6NLFuNyI",
+                  "ref": "24f9d706-18d5-4e89-9e8e-7dd1218a4bcf",
+                  "label": "Over the counter supplements"
+                },
+                {
+                  "id": "kwuwHn8AuTD3",
+                  "ref": "33a731d3-93d2-4130-9802-5faf244136ac",
+                  "label": "Prescription pills (metformin, glyburide, etc.)"
+                },
+                {
+                  "id": "OFkKn78R8S5w",
+                  "ref": "86962b8d-8bde-47e9-9979-d2e9b2860da2",
+                  "label": "Long acting insulin (Lantus, TouJeo, etc.)"
+                },
+                {
+                  "id": "dAAb4vAMXphM",
+                  "ref": "10f5f100-81b2-4e3a-854a-e74b23da64b8",
+                  "label": "Other insulins"
+                },
+                {
+                  "id": "0l8W1J0Gvx6c",
+                  "ref": "49eb3a6b-c5ad-4008-adb5-b92bda77f513",
+                  "label": "Sliding scale insulin"
+                },
+                {
+                  "id": "hK0Vg0As0ftR",
+                  "ref": "799f4581-39b0-4195-9f91-cf8ce2ec9116",
+                  "label": "Meal coverage insulin"
+                },
+                {
+                  "id": "fudq0iUFe3xt",
+                  "ref": "a2f24fe4-4e6b-428e-b452-83f41b44c30f",
+                  "label": "Nothing"
+                },
+                {
+                  "id": "DS4v47pxibNO",
+                  "ref": "caf313ce-3fea-4f8d-a44e-19468bf5c083",
+                  "label": "Other"
+                }
+              ]
+            },
+            "validations": {
+              "required": false
+            },
+            "type": "multiple_choice"
+          },
+          {
+            "id": "PtQRCTc9psIw",
+            "title": "Please share more details:",
+            "ref": "8ee92688-0aff-479d-ad00-ec1530dce17a",
+            "properties": {},
+            "validations": {
+              "required": false
+            },
+            "type": "short_text"
+          }
+        ]
+      },
+      "type": "group"
+    },
+    {
+      "id": "GarT7t8Io3qc",
+      "title": "Hypertension",
+      "ref": "0709866b-04d6-4339-9f34-480d2f4c81dd",
+      "properties": {
+        "button_text": "Continue",
+        "show_button": false,
+        "fields": [
+          {
+            "id": "fmGYw9FIpmEU",
+            "title": "Would you like to discuss Hypertension (high blood pressure)?",
+            "ref": "257b5962-e30b-4d1f-b752-e4abca0a570d",
+            "properties": {},
+            "validations": {
+              "required": false
+            },
+            "type": "yes_no"
+          },
+          {
+            "id": "zlE7JuV9iFHs",
+            "title": "How old were you when first diagnosed with high blood pressure?",
+            "ref": "33c73ff7-fa6b-40f4-90cb-5e6488ea6ac5",
+            "properties": {},
+            "validations": {
+              "required": false
+            },
+            "type": "number"
+          },
+          {
+            "id": "UTmpzKfUl9Cc",
+            "title": "How do you treat your high blood pressure?",
+            "ref": "883939b3-5c06-4f34-87a5-c2657a609d4b",
+            "properties": {
+              "randomize": false,
+              "allow_multiple_selection": true,
+              "allow_other_choice": false,
+              "vertical_alignment": true,
+              "choices": [
+                {
+                  "id": "tLDXPzRdGilw",
+                  "ref": "cd2dc88d-27ce-4abb-8c7b-81031c0038f4",
+                  "label": "Diet"
+                },
+                {
+                  "id": "8KsOqvyfa53X",
+                  "ref": "38e36689-2ff2-4a51-9664-71d84836bb06",
+                  "label": "Exercise"
+                },
+                {
+                  "id": "yip01DNjNmPg",
+                  "ref": "082a1c54-bd04-487f-ac75-5116b60baad7",
+                  "label": "Over the counter supplements"
+                },
+                {
+                  "id": "abhYgoGgGLYC",
+                  "ref": "ae9bc9f8-08c6-489b-8641-0f4335c52ec2",
+                  "label": "Prescription medications"
+                },
+                {
+                  "id": "3b2q4mDDl04e",
+                  "ref": "ccf5f6ed-c563-4169-a86d-9ec23131a50c",
+                  "label": "Nothing, no treatments"
+                },
+                {
+                  "id": "TrNaCVocXSti",
+                  "ref": "8632f660-7832-46e8-8d05-e2c6cf5fef31",
+                  "label": "Other"
+                }
+              ]
+            },
+            "validations": {
+              "required": false
+            },
+            "type": "multiple_choice"
+          },
+          {
+            "id": "XgHeAs5rw4Vo",
+            "title": "Please share more details:",
+            "ref": "84a90275-a7ce-49c2-b2c5-c66247ffcf98",
+            "properties": {},
+            "validations": {
+              "required": false
+            },
+            "type": "short_text"
+          }
+        ]
+      },
+      "type": "group"
+    },
+    {
+      "id": "4N7u8XG3sFLC",
+      "title": "Hyperlipidemia",
+      "ref": "6f8e14ff-810a-453c-a2f8-455595cc25f7",
+      "properties": {
+        "button_text": "Continue",
+        "show_button": false,
+        "fields": [
+          {
+            "id": "zTnTkCtgBAA4",
+            "title": "Would you like to discuss Hyperlipidemia (high cholesterol)?",
+            "ref": "3f7cdb5c-ebb2-4ea8-9e05-c36400f5380a",
+            "properties": {},
+            "validations": {
+              "required": false
+            },
+            "type": "yes_no"
+          },
+          {
+            "id": "65Rd1gy9QqDU",
+            "title": "How old were you when first diagnosed with high cholesterol?",
+            "ref": "7af3eb65-dda9-4ce8-8049-770e4d6cd786",
+            "properties": {},
+            "validations": {
+              "required": false
+            },
+            "type": "number"
+          },
+          {
+            "id": "hzEPmdfD0uJr",
+            "title": "How do you treat your high cholesterol?",
+            "ref": "8e9e8702-7ab4-431f-b0f5-d0d2cd3261fb",
+            "properties": {
+              "randomize": false,
+              "allow_multiple_selection": true,
+              "allow_other_choice": false,
+              "vertical_alignment": true,
+              "choices": [
+                {
+                  "id": "XduMz6jc4LBf",
+                  "ref": "59e12f19-87cc-4c2d-8ee5-b8b83eaf76a2",
+                  "label": "Diet"
+                },
+                {
+                  "id": "vJ8oLRRP1FuF",
+                  "ref": "5a538d8b-0f28-4e41-9335-9e20bcef3017",
+                  "label": "Exercise"
+                },
+                {
+                  "id": "C2VU9dkAFpqx",
+                  "ref": "2dcefd6f-3c60-4735-a334-caf4da5e5650",
+                  "label": "Prescription statin (eg simvastatin, atorvastatin, etc.)"
+                },
+                {
+                  "id": "PyBeZxZNWUpn",
+                  "ref": "e593faa3-0e77-4b52-81ae-1620c295147f",
+                  "label": "Other prescription cholesterol medication (Zetia)"
+                },
+                {
+                  "id": "NLHyqOkS7wzy",
+                  "ref": "5548fd30-2b0c-411d-b986-3f6dd83dc11b",
+                  "label": "Over the counter supplement(s)"
+                },
+                {
+                  "id": "nPnBIFfCR5cC",
+                  "ref": "8e54a553-c726-4da2-9b2e-98620ddb676c",
+                  "label": "Nothing; no treatments"
+                },
+                {
+                  "id": "xt3svxIS00DP",
+                  "ref": "0cd126c7-72aa-4b63-8b44-3202fc07057f",
+                  "label": "Other"
+                }
+              ]
+            },
+            "validations": {
+              "required": false
+            },
+            "type": "multiple_choice"
+          },
+          {
+            "id": "aSyUiatp3mt6",
+            "title": "Please share more details:",
+            "ref": "599628bc-fdb6-49ae-8dda-5063fa34f565",
+            "properties": {},
+            "validations": {
+              "required": false
+            },
+            "type": "short_text"
+          }
+        ]
+      },
+      "type": "group"
+    },
+    {
+      "id": "uEkI6yMwHp9A",
+      "title": "Hypothyroidism",
+      "ref": "288d2574-39ef-4a09-ade7-ed5f00d2ea78",
+      "properties": {
+        "button_text": "Continue",
+        "show_button": false,
+        "fields": [
+          {
+            "id": "YintSzPeZwNi",
+            "title": "Would you like to discuss Hypothyroidism (low or slow thyroid function)?",
+            "ref": "5c96ea8f-3f79-4784-af6f-a2f63cc4dc5d",
+            "properties": {},
+            "validations": {
+              "required": false
+            },
+            "type": "yes_no"
+          },
+          {
+            "id": "uONQIHuGNsp6",
+            "title": "How old were you when first diagnosed with hypothyroidism (slow/low thyroid function)?",
+            "ref": "87ab4476-c084-41b5-8add-8d8e26e5d4f8",
+            "properties": {},
+            "validations": {
+              "required": false
+            },
+            "type": "number"
+          },
+          {
+            "id": "EVCHMoUMHjFm",
+            "title": "Are you experiencing any of the following?",
+            "ref": "0393e7ba-45e8-4325-b0d2-291411e8f319",
+            "properties": {
+              "randomize": false,
+              "allow_multiple_selection": true,
+              "allow_other_choice": false,
+              "vertical_alignment": true,
+              "choices": [
+                {
+                  "id": "hXhZ36dPF9cz",
+                  "ref": "c4bcedda-e899-4557-b645-1ef2b75a8c44",
+                  "label": "Lump in your neck"
+                },
+                {
+                  "id": "YqS1FldPhKuQ",
+                  "ref": "6af231bd-9cd3-4b36-a2b2-b839f2de8071",
+                  "label": "Decreased libido (sexual desire)"
+                },
+                {
+                  "id": "kBhITb4wRJSq",
+                  "ref": "52ae8ae7-4d97-4fcf-a333-4d5be3f20274",
+                  "label": "Coarse hair"
+                },
+                {
+                  "id": "tENaniO9Wloe",
+                  "ref": "9a5f6632-1414-4fea-995d-9684abd96fa3",
+                  "label": "Dry, rough, pale skin"
+                },
+                {
+                  "id": "x3Yz2JN4p3mq",
+                  "ref": "cb0d6abc-3d86-4faf-a5c4-0ca23bd39fed",
+                  "label": "Fatigue"
+                },
+                {
+                  "id": "HhDFtdyiBbB6",
+                  "ref": "2c17a3cb-31f5-425d-81cf-eb1c1899ab91",
+                  "label": "Abnormal menstrual cycles"
+                },
+                {
+                  "id": "H6o5oNL2aVoN",
+                  "ref": "57ebc6be-d322-41fb-836d-3578ff0a0d91",
+                  "label": "Hair loss"
+                },
+                {
+                  "id": "YL8M0vkgx84h",
+                  "ref": "42a07fbf-5bf3-401a-82e5-e09f015ba887",
+                  "label": "Muscle cramps and/or weakness"
+                },
+                {
+                  "id": "RSUdWl1tq63O",
+                  "ref": "f968529b-5df3-48d6-80cb-a60bbf69cb38",
+                  "label": "Unexplained weight gain"
+                },
+                {
+                  "id": "C0tFajn5sfiz",
+                  "ref": "f95699a0-f841-4715-a71f-be63ace2cbde",
+                  "label": "Unintentional weight loss"
+                },
+                {
+                  "id": "j3fyeBpcQc3H",
+                  "ref": "8c582d99-c45a-4b00-8ef2-a34a43b308a6",
+                  "label": "Constipation"
+                },
+                {
+                  "id": "mSjA1jdzlEx1",
+                  "ref": "6ebee8ac-ce43-4ce1-8f65-9d213e7db934",
+                  "label": "Loose bowels"
+                },
+                {
+                  "id": "rGrMttvcMjbH",
+                  "ref": "f4d0c854-a79b-4e50-b22a-b96eca2f753a",
+                  "label": "Depression and/or anxiety"
+                },
+                {
+                  "id": "LihDE1nwxe3r",
+                  "ref": "223edfa0-cf2f-4a80-8d96-35c731f97234",
+                  "label": "Other"
+                },
+                {
+                  "id": "ZwJYFpx5RSbr",
+                  "ref": "8d702ea8-7b36-4bf4-abf9-cbebfe2a3ee7",
+                  "label": "None of the above; No current symptoms of thyroid problems"
+                }
+              ]
+            },
+            "validations": {
+              "required": false
+            },
+            "type": "multiple_choice"
+          },
+          {
+            "id": "QTWPpmhgr1Lt",
+            "title": "Please share more details:",
+            "ref": "bdf9791e-74f0-4d94-b268-57215c416133",
+            "properties": {},
+            "validations": {
+              "required": false
+            },
+            "type": "short_text"
+          }
+        ]
+      },
+      "type": "group"
+    },
+    {
+      "id": "ifUc0auAZqmp",
+      "title": "Mental Health",
+      "ref": "4dc7db37-d386-4d46-b18d-7654c4c93f57",
+      "properties": {
+        "button_text": "Continue",
+        "show_button": false,
+        "fields": [
+          {
+            "id": "jPs6LhapkRAT",
+            "title": "Would you like to discuss mild to moderate depression?",
+            "ref": "481bb5f7-22cc-4ba3-a29f-1803c33c65b5",
+            "properties": {},
+            "validations": {
+              "required": false
+            },
+            "type": "yes_no"
+          },
+          {
+            "id": "3IYS63i0JhhV",
+            "title": "How old were you when first diagnosed with depression?",
+            "ref": "6b65383a-8e48-4e6f-bdd9-e41893a18677",
+            "properties": {
+              "description": "Skip if never officially diagnosed"
+            },
+            "validations": {
+              "required": false
+            },
+            "type": "number"
+          },
+          {
+            "id": "2kKq7ZDMK1xG",
+            "title": "For the next few questions, think about the last 2 weeks. How often have you been bothered by any of the following problems?",
+            "ref": "eead6ba3-8115-47cd-b514-88dd496030bb",
+            "properties": {
+              "button_text": "Continue",
+              "hide_marks": false
+            },
+            "type": "statement"
+          },
+          {
+            "id": "AEfxuyGOSSWf",
+            "title": "Little interest or pleasure in doing things",
+            "ref": "f29c30bf-d169-4b2d-a23c-f0ffbf91a25b",
+            "properties": {
+              "randomize": false,
+              "allow_multiple_selection": false,
+              "allow_other_choice": false,
+              "vertical_alignment": true,
+              "choices": [
+                {
+                  "id": "PrWvvz9vAVJH",
+                  "ref": "7a5baa96-101d-47c0-ac4d-ca0a52f95679",
+                  "label": "0 - Not at all"
+                },
+                {
+                  "id": "yZdCemI0lHNL",
+                  "ref": "bb492924-9024-4d7f-9165-4e968383989c",
+                  "label": "1 - Several days"
+                },
+                {
+                  "id": "dPLalWQ1nPWH",
+                  "ref": "1fb6a56f-db13-4495-8d95-cc1afb3ea16b",
+                  "label": "2 - More than half the days"
+                },
+                {
+                  "id": "NpObUox6rjig",
+                  "ref": "7fe3d436-c642-4c1d-a18e-8b2edebcceb9",
+                  "label": "3 - Nearly every day"
+                }
+              ]
+            },
+            "validations": {
+              "required": false
+            },
+            "type": "multiple_choice"
+          },
+          {
+            "id": "LH7dXerIUXFJ",
+            "title": "Feeling down, depressed, or hopeless",
+            "ref": "ca769ee7-b96e-442f-a005-8af1ccc61db2",
+            "properties": {
+              "randomize": false,
+              "allow_multiple_selection": false,
+              "allow_other_choice": false,
+              "vertical_alignment": true,
+              "choices": [
+                {
+                  "id": "s7N710IlUZHF",
+                  "ref": "1cbeb92b-6bb6-4f69-b0d1-8fcb5af03938",
+                  "label": "0 - Not at all"
+                },
+                {
+                  "id": "OX39TfNwfebv",
+                  "ref": "052f398a-048c-4b66-9812-f6c26ec42bc8",
+                  "label": "1 - Several days"
+                },
+                {
+                  "id": "bsSGec1Lmj2q",
+                  "ref": "ac499bff-d7de-4dc1-9edc-e5fee08ebdda",
+                  "label": "2 - More than half the days"
+                },
+                {
+                  "id": "JFWwSPZUJFjn",
+                  "ref": "f7384cc0-9b66-4450-a2de-aa221322c759",
+                  "label": "3 - Nearly every day"
+                }
+              ]
+            },
+            "validations": {
+              "required": false
+            },
+            "type": "multiple_choice"
+          },
+          {
+            "id": "zJDrMJjlYu7A",
+            "title": "Trouble sleeping or sleeping too much",
+            "ref": "f7bc283e-905f-4433-84fe-bf389fc21a9f",
+            "properties": {
+              "randomize": false,
+              "allow_multiple_selection": false,
+              "allow_other_choice": false,
+              "vertical_alignment": true,
+              "choices": [
+                {
+                  "id": "5uDOiIHZ6tWl",
+                  "ref": "1cbeb92b-6bb6-4f69-b0d1-8fcb5af03938",
+                  "label": "0 - Not at all"
+                },
+                {
+                  "id": "syS4xyfaK1df",
+                  "ref": "052f398a-048c-4b66-9812-f6c26ec42bc8",
+                  "label": "1 - Several days"
+                },
+                {
+                  "id": "7xail4b4K6wj",
+                  "ref": "ac499bff-d7de-4dc1-9edc-e5fee08ebdda",
+                  "label": "2 - More than half the days"
+                },
+                {
+                  "id": "UJrBk5fPAJgO",
+                  "ref": "f7384cc0-9b66-4450-a2de-aa221322c759",
+                  "label": "3 - Nearly every day"
+                }
+              ]
+            },
+            "validations": {
+              "required": false
+            },
+            "type": "multiple_choice"
+          },
+          {
+            "id": "pkRFzwr8BEDn",
+            "title": "Feeling tired or having little energy ",
+            "ref": "41095f1e-160d-42de-ad0f-9971b7a3fb0d",
+            "properties": {
+              "randomize": false,
+              "allow_multiple_selection": false,
+              "allow_other_choice": false,
+              "vertical_alignment": true,
+              "choices": [
+                {
+                  "id": "p7OIQQBu4G8V",
+                  "ref": "1cbeb92b-6bb6-4f69-b0d1-8fcb5af03938",
+                  "label": "0 - Not at all"
+                },
+                {
+                  "id": "jC6lmuf5oaqN",
+                  "ref": "052f398a-048c-4b66-9812-f6c26ec42bc8",
+                  "label": "1 - Several days"
+                },
+                {
+                  "id": "AwCFL55ecBXU",
+                  "ref": "ac499bff-d7de-4dc1-9edc-e5fee08ebdda",
+                  "label": "2 - More than half the days"
+                },
+                {
+                  "id": "FYsgWHvG7T2R",
+                  "ref": "f7384cc0-9b66-4450-a2de-aa221322c759",
+                  "label": "3 - Nearly every day"
+                }
+              ]
+            },
+            "validations": {
+              "required": false
+            },
+            "type": "multiple_choice"
+          },
+          {
+            "id": "H70UB9aqhRYA",
+            "title": "Poor appetite or overeating  ",
+            "ref": "6ce2fcab-6003-4321-87b4-c1170407af8d",
+            "properties": {
+              "randomize": false,
+              "allow_multiple_selection": false,
+              "allow_other_choice": false,
+              "vertical_alignment": true,
+              "choices": [
+                {
+                  "id": "UL1tobPNOkri",
+                  "ref": "1cbeb92b-6bb6-4f69-b0d1-8fcb5af03938",
+                  "label": "0 - Not at all"
+                },
+                {
+                  "id": "uQPXhnXBWCVR",
+                  "ref": "052f398a-048c-4b66-9812-f6c26ec42bc8",
+                  "label": "1 - Several days"
+                },
+                {
+                  "id": "rrdoViyHPAPw",
+                  "ref": "ac499bff-d7de-4dc1-9edc-e5fee08ebdda",
+                  "label": "2 - More than half the days"
+                },
+                {
+                  "id": "gTJB9o6HdxQz",
+                  "ref": "f7384cc0-9b66-4450-a2de-aa221322c759",
+                  "label": "3 - Nearly every day"
+                }
+              ]
+            },
+            "validations": {
+              "required": false
+            },
+            "type": "multiple_choice"
+          },
+          {
+            "id": "7C5t6cEptzmc",
+            "title": "Feeling bad about yourself — or that you are a failure or have let yourself or your family down  ",
+            "ref": "f851eab0-adb1-4abe-828f-36b1a67a9735",
+            "properties": {
+              "randomize": false,
+              "allow_multiple_selection": false,
+              "allow_other_choice": false,
+              "vertical_alignment": true,
+              "choices": [
+                {
+                  "id": "wrfe542xvdOw",
+                  "ref": "1cbeb92b-6bb6-4f69-b0d1-8fcb5af03938",
+                  "label": "0 - Not at all"
+                },
+                {
+                  "id": "rfr79zRIKJxf",
+                  "ref": "052f398a-048c-4b66-9812-f6c26ec42bc8",
+                  "label": "1 - Several days"
+                },
+                {
+                  "id": "2rlnBq6EE4oU",
+                  "ref": "ac499bff-d7de-4dc1-9edc-e5fee08ebdda",
+                  "label": "2 - More than half the days"
+                },
+                {
+                  "id": "fc2Yps8Tv0Ko",
+                  "ref": "f7384cc0-9b66-4450-a2de-aa221322c759",
+                  "label": "3 - Nearly every day"
+                }
+              ]
+            },
+            "validations": {
+              "required": false
+            },
+            "type": "multiple_choice"
+          },
+          {
+            "id": "k2RrJofS13Vw",
+            "title": "Trouble concentrating on things, such as reading the newspaper or watching television:   ",
+            "ref": "14753dbc-7642-46a9-a885-91cd193f776f",
+            "properties": {
+              "randomize": false,
+              "allow_multiple_selection": false,
+              "allow_other_choice": false,
+              "vertical_alignment": true,
+              "choices": [
+                {
+                  "id": "8XoixGP7sN2I",
+                  "ref": "1cbeb92b-6bb6-4f69-b0d1-8fcb5af03938",
+                  "label": "0 - Not at all"
+                },
+                {
+                  "id": "gGiFyBoFwXvz",
+                  "ref": "052f398a-048c-4b66-9812-f6c26ec42bc8",
+                  "label": "1 - Several days"
+                },
+                {
+                  "id": "doxpTXeRxz6Z",
+                  "ref": "ac499bff-d7de-4dc1-9edc-e5fee08ebdda",
+                  "label": "2 - More than half the days"
+                },
+                {
+                  "id": "RQ21X0ZWhKRT",
+                  "ref": "f7384cc0-9b66-4450-a2de-aa221322c759",
+                  "label": "3 - Nearly every day"
+                }
+              ]
+            },
+            "validations": {
+              "required": false
+            },
+            "type": "multiple_choice"
+          },
+          {
+            "id": "bSAp2LucMsvv",
+            "title": "Moving or speaking so slowly that other people could have noticed?  Or the opposite — being so fidgety or restless that you have been moving around a lot more than usual:  ",
+            "ref": "1f1e4eb6-cdf9-4c97-bb36-b8d6ee4b9253",
+            "properties": {
+              "randomize": false,
+              "allow_multiple_selection": false,
+              "allow_other_choice": false,
+              "vertical_alignment": true,
+              "choices": [
+                {
+                  "id": "7x3cag2034f4",
+                  "ref": "1cbeb92b-6bb6-4f69-b0d1-8fcb5af03938",
+                  "label": "0 - Not at all"
+                },
+                {
+                  "id": "stU4wJxqyryq",
+                  "ref": "052f398a-048c-4b66-9812-f6c26ec42bc8",
+                  "label": "1 - Several days"
+                },
+                {
+                  "id": "cvZDvOWJg4Sz",
+                  "ref": "ac499bff-d7de-4dc1-9edc-e5fee08ebdda",
+                  "label": "2 - More than half the days"
+                },
+                {
+                  "id": "aZjaT5bNhEIU",
+                  "ref": "f7384cc0-9b66-4450-a2de-aa221322c759",
+                  "label": "3 - Nearly every day"
+                }
+              ]
+            },
+            "validations": {
+              "required": false
+            },
+            "type": "multiple_choice"
+          },
+          {
+            "id": "SyC4BdfT6pKd",
+            "title": "Thoughts that you would be better off dead or of hurting yourself   ",
+            "ref": "6b629b2a-7455-4ce3-8443-b2a1ea9f94a6",
+            "properties": {
+              "randomize": false,
+              "allow_multiple_selection": false,
+              "allow_other_choice": false,
+              "vertical_alignment": true,
+              "choices": [
+                {
+                  "id": "AoH03zBUgqaA",
+                  "ref": "1cbeb92b-6bb6-4f69-b0d1-8fcb5af03938",
+                  "label": "0 - Not at all"
+                },
+                {
+                  "id": "3HgaFO5GbTFH",
+                  "ref": "052f398a-048c-4b66-9812-f6c26ec42bc8",
+                  "label": "1 - Several days"
+                },
+                {
+                  "id": "kZEipdjSrYbM",
+                  "ref": "ac499bff-d7de-4dc1-9edc-e5fee08ebdda",
+                  "label": "2 - More than half the days"
+                },
+                {
+                  "id": "SeUxv1Z9Mtuj",
+                  "ref": "f7384cc0-9b66-4450-a2de-aa221322c759",
+                  "label": "3 - Nearly every day"
+                }
+              ]
+            },
+            "validations": {
+              "required": false
+            },
+            "type": "multiple_choice"
+          },
+          {
+            "id": "HuZFkdYlvfwo",
+            "title": "Would you like to discuss anxiety?",
+            "ref": "a07cfd6c-5947-4db1-ae11-08018c55cb34",
+            "properties": {},
+            "validations": {
+              "required": false
+            },
+            "type": "yes_no"
+          }
+        ]
+      },
+      "type": "group"
+    },
+    {
+      "id": "hdAiYcY8swbP",
+      "title": "GAD-7 Scale",
+      "ref": "34581527-ad20-41ce-be0e-ff5cac6f23a2",
+      "properties": {
+        "button_text": "Continue",
+        "show_button": false,
+        "fields": [
+          {
+            "id": "o0wuqjB4djjS",
+            "title": "How old were you when first diagnosed with anxiety?",
+            "ref": "a743e9a4-7d57-4e6a-9815-d84a4f5d556a",
+            "properties": {
+              "description": "Skip if you've never been officially diagnosed with anxiety"
+            },
+            "validations": {
+              "required": false
+            },
+            "type": "number"
+          },
+          {
+            "id": "Yu2uew7SrMu1",
+            "title": "For the next few questions, think about the last 2 weeks. How often have you been bothered by any of the following problems?",
+            "ref": "a9e9eaea-4dd3-4e91-af32-9e1a03b3f943",
+            "properties": {
+              "button_text": "Continue",
+              "hide_marks": false
+            },
+            "type": "statement"
+          },
+          {
+            "id": "aII8PeHThzPb",
+            "title": "Feeling nervous, anxious or on edge:",
+            "ref": "4985669f-dd7c-4b8c-867e-5c4dad225e2f",
+            "properties": {
+              "randomize": false,
+              "allow_multiple_selection": false,
+              "allow_other_choice": false,
+              "vertical_alignment": true,
+              "choices": [
+                {
+                  "id": "sUtKxFxfzJbI",
+                  "ref": "3f683b57-64aa-4c14-a673-5cde09566ded",
+                  "label": "0 - Not at all"
+                },
+                {
+                  "id": "iMV0I1ufeAMt",
+                  "ref": "4762ae8d-353e-48f0-8a82-f5bf5361b0d3",
+                  "label": "1 - Several days"
+                },
+                {
+                  "id": "7kGJcRc7GBo1",
+                  "ref": "d56057f2-ef48-4f14-8b6b-6bb134be3e9a",
+                  "label": "2 - More than half the days"
+                },
+                {
+                  "id": "oc5T5MLcBB5Z",
+                  "ref": "84a7e72d-bf66-4419-90f1-7ff70f05316f",
+                  "label": "3 - Nearly every day"
+                }
+              ]
+            },
+            "validations": {
+              "required": false
+            },
+            "type": "multiple_choice"
+          },
+          {
+            "id": "gSMKYCUJoEHI",
+            "title": "Not being able to stop or control worrying:",
+            "ref": "b11bd8ed-0f9b-47b2-918c-8ad1fc69f1d7",
+            "properties": {
+              "randomize": false,
+              "allow_multiple_selection": false,
+              "allow_other_choice": false,
+              "vertical_alignment": true,
+              "choices": [
+                {
+                  "id": "jybMBbYDJFY1",
+                  "ref": "3f683b57-64aa-4c14-a673-5cde09566ded",
+                  "label": "0 - Not at all"
+                },
+                {
+                  "id": "DOQYoC2fR9Sb",
+                  "ref": "dcc62a12-348d-4bf9-8fcb-686be9cf7de7",
+                  "label": "1 - Several days"
+                },
+                {
+                  "id": "snerDEUb0yN9",
+                  "ref": "fafd2407-0d6c-4ae2-9bc6-56598095d101",
+                  "label": "2 - More than half the days"
+                },
+                {
+                  "id": "H47Lx1wFioPu",
+                  "ref": "b4bf712e-b4be-4cb9-944d-adfe7c0c6882",
+                  "label": "3 - Nearly every day"
+                }
+              ]
+            },
+            "validations": {
+              "required": false
+            },
+            "type": "multiple_choice"
+          },
+          {
+            "id": "EuZueqTnn4mA",
+            "title": "Worrying too much about different things:",
+            "ref": "f4582d24-769b-4eea-a0b5-54eb942ab60a",
+            "properties": {
+              "randomize": false,
+              "allow_multiple_selection": false,
+              "allow_other_choice": false,
+              "vertical_alignment": true,
+              "choices": [
+                {
+                  "id": "8T5PARghqGiS",
+                  "ref": "3f683b57-64aa-4c14-a673-5cde09566ded",
+                  "label": "0 - Not at all"
+                },
+                {
+                  "id": "2XNyiMcv2cxw",
+                  "ref": "a3e1dacf-0530-4d10-80e6-b4d2344ce37c",
+                  "label": "1 - Several days"
+                },
+                {
+                  "id": "19OQ7u5vamdM",
+                  "ref": "80bda946-c186-43ce-92d8-e0bc2e5f6fec",
+                  "label": "2 - More than half the days"
+                },
+                {
+                  "id": "HG3bzvSdDDKv",
+                  "ref": "287ed1ba-368f-4c85-96e9-cb4181f352de",
+                  "label": "3 - Nearly every day"
+                }
+              ]
+            },
+            "validations": {
+              "required": false
+            },
+            "type": "multiple_choice"
+          },
+          {
+            "id": "NYVvDQeOGhSc",
+            "title": "Trouble relaxing:",
+            "ref": "2749c6bb-2a0b-4edd-80f4-2272d1ba7b17",
+            "properties": {
+              "randomize": false,
+              "allow_multiple_selection": false,
+              "allow_other_choice": false,
+              "vertical_alignment": true,
+              "choices": [
+                {
+                  "id": "XHS1uYg02qUt",
+                  "ref": "3f683b57-64aa-4c14-a673-5cde09566ded",
+                  "label": "0 - Not at all"
+                },
+                {
+                  "id": "6kU1rvcx1y9e",
+                  "ref": "e5bab387-40ef-42f5-9f2f-bf6a9c57e3d4",
+                  "label": "1 - Several days"
+                },
+                {
+                  "id": "RTmESN2c5dKt",
+                  "ref": "47142e2e-2d14-4588-b1b0-0c9468ebb50c",
+                  "label": "2 - More than half the days"
+                },
+                {
+                  "id": "9tLb1raWDYwj",
+                  "ref": "1f150e4c-d57c-4580-b2cf-ac07a46626bc",
+                  "label": "3 - Nearly every day"
+                }
+              ]
+            },
+            "validations": {
+              "required": false
+            },
+            "type": "multiple_choice"
+          },
+          {
+            "id": "LZKrORIpNB0k",
+            "title": "Being so restless that it's hard to sit still:",
+            "ref": "87ddfda2-1677-4c2c-b826-642391b86111",
+            "properties": {
+              "randomize": false,
+              "allow_multiple_selection": false,
+              "allow_other_choice": false,
+              "vertical_alignment": true,
+              "choices": [
+                {
+                  "id": "B1c6qLnoZnS7",
+                  "ref": "3f683b57-64aa-4c14-a673-5cde09566ded",
+                  "label": "0 - Not at all"
+                },
+                {
+                  "id": "9WpAckl17VKA",
+                  "ref": "1f687f04-c465-47a3-84db-7cbed0bde6c3",
+                  "label": "1 - Several days"
+                },
+                {
+                  "id": "dzDvMPRGR1Zh",
+                  "ref": "52f6fabf-a24d-4702-a5d0-f2a6a1595993",
+                  "label": "2 - More than half the days"
+                },
+                {
+                  "id": "uNcweWhUJuZQ",
+                  "ref": "52a3750b-cc69-4f3a-9000-c7115527c694",
+                  "label": "3 - Nearly every day"
+                }
+              ]
+            },
+            "validations": {
+              "required": false
+            },
+            "type": "multiple_choice"
+          },
+          {
+            "id": "9Pn905gQsTw8",
+            "title": "Becoming easily annoyed or irritable:",
+            "ref": "9357ada5-ca54-41bb-87d9-fbd29c41ab80",
+            "properties": {
+              "randomize": false,
+              "allow_multiple_selection": false,
+              "allow_other_choice": false,
+              "vertical_alignment": true,
+              "choices": [
+                {
+                  "id": "LdlifMzREjG3",
+                  "ref": "3f683b57-64aa-4c14-a673-5cde09566ded",
+                  "label": "0 - Not at all"
+                },
+                {
+                  "id": "PJNOUCNYJ2Tu",
+                  "ref": "7b31781e-1481-45a5-99cc-43cf2c523b94",
+                  "label": "1 - Several days"
+                },
+                {
+                  "id": "oyo9kd7ezvKZ",
+                  "ref": "ff5e5fba-d5b8-4a31-bf1b-cc89dcecfcdb",
+                  "label": "2 - More than half the days"
+                },
+                {
+                  "id": "mWxalxy8NsTw",
+                  "ref": "6feade6a-5b9c-4783-b82f-f2d9af5e6ae7",
+                  "label": "3 - Nearly every day"
+                }
+              ]
+            },
+            "validations": {
+              "required": false
+            },
+            "type": "multiple_choice"
+          },
+          {
+            "id": "2KB8EZKorpmz",
+            "title": "Feeling afraid as if something awful might\nhappen:",
+            "ref": "59829c15-ef85-48d3-9c97-41e3a4627a27",
+            "properties": {
+              "randomize": false,
+              "allow_multiple_selection": false,
+              "allow_other_choice": false,
+              "vertical_alignment": true,
+              "choices": [
+                {
+                  "id": "KZxZ0eqTjgN8",
+                  "ref": "3f683b57-64aa-4c14-a673-5cde09566ded",
+                  "label": "0 - Not at all"
+                },
+                {
+                  "id": "8nNy4nG54YvX",
+                  "ref": "50d8515f-feb4-4900-8ce1-ddbe298c3be6",
+                  "label": "1 - Several days"
+                },
+                {
+                  "id": "5oEPMKA2TdH9",
+                  "ref": "9b02843b-8ca3-42d4-a8be-e16e7bf5331a",
+                  "label": "2 - More than half the days"
+                },
+                {
+                  "id": "iVEhg29I5DI8",
+                  "ref": "f4341a1c-332f-42c7-859f-7c4905aba3ec",
+                  "label": "3 - Nearly every day"
+                }
+              ]
+            },
+            "validations": {
+              "required": false
+            },
+            "type": "multiple_choice"
+          }
+        ]
+      },
+      "type": "group"
+    },
+    {
+      "id": "9T4lQHqwgjab",
+      "title": "If you answered \"Several days\", \"More than half the days\", or \"Nearly every day\" to any of the previous questions about problems...how difficult have these problems made it for you to do your work, take care of things at  home, or get along with other people?",
+      "ref": "b045eb9e-65f4-4685-a416-ea0d64ead194",
+      "properties": {
+        "description": "Skip if you answered \"Not at all\" to all previous questions",
+        "randomize": false,
+        "allow_multiple_selection": false,
+        "allow_other_choice": false,
+        "vertical_alignment": true,
+        "choices": [
+          {
+            "id": "D5dSlEKQoG8q",
+            "ref": "e8261ae1-ec19-483d-a497-9b4c3a5861df",
+            "label": "Not difficult at all"
+          },
+          {
+            "id": "EUi8zgdwiKG3",
+            "ref": "1feb8565-38af-4bf5-92e4-f38e1a951ae7",
+            "label": "Somewhat difficult"
+          },
+          {
+            "id": "eVPG8O4HZRBs",
+            "ref": "c7877d63-c5b4-48fb-9564-42a21cafe976",
+            "label": "Very difficult"
+          },
+          {
+            "id": "5Pu5AGgnqzy3",
+            "ref": "0d99bb16-fe33-4512-bc67-4161263a4edf",
+            "label": "Extremely difficult"
+          }
+        ]
+      },
+      "validations": {
+        "required": false
+      },
+      "type": "multiple_choice"
+    },
+    {
+      "id": "3acnfO79Bmbg",
+      "title": "Are there any other details or background you'd like to share with your provider?",
+      "ref": "daab8076-557d-4572-a489-14d08038ff4b",
+      "properties": {},
+      "validations": {
+        "required": false
+      },
+      "type": "yes_no"
+    },
+    {
+      "id": "t2u7MSLqs5zP",
+      "title": "Please share here:",
+      "ref": "c5a79da8-d8f4-4250-9a4a-169d1af7e805",
+      "properties": {},
+      "validations": {
+        "required": true
+      },
+      "type": "long_text"
+    },
+    {
+      "id": "r607rMf9WMEO",
+      "title": "Allergic Rhinitis",
+      "ref": "dcab50b0-af56-4d66-a0f7-4df00c41d322",
+      "properties": {
+        "button_text": "Continue",
+        "show_button": false,
+        "fields": [
+          {
+            "id": "XS8FqYAru6Q2",
+            "title": "Did you want to discuss allergic rhinitis (seasonal allergies)?",
+            "ref": "a099c975-05d2-4368-8ead-8b0ca02cdbf9",
+            "properties": {},
+            "validations": {
+              "required": false
+            },
+            "type": "yes_no"
+          },
+          {
+            "id": "mpbINufrlvAN",
+            "title": "How many years have you been diagnosed with or suspected seasonal allergies?",
+            "ref": "7d78fe9a-8a68-42e9-a732-46e8a24ac379",
+            "properties": {
+              "description": "Allergies to dust, pollen, mold, etc."
+            },
+            "validations": {
+              "required": false
+            },
+            "type": "number"
+          },
+          {
+            "id": "MIUr1vCpdnzX",
+            "title": "What have you used to treat your allergies?",
+            "ref": "62ef617a-90c7-4dfe-87e6-98f700cc315f",
+            "properties": {
+              "randomize": false,
+              "allow_multiple_selection": true,
+              "allow_other_choice": false,
+              "vertical_alignment": true,
+              "choices": [
+                {
+                  "id": "wimPftWDrtFU",
+                  "ref": "1c2bb9ad-cc34-4790-a738-4c47fe29e33c",
+                  "label": "Oral over the counter pills (Claritin, Allegra, Zyrtec, etc)"
+                },
+                {
+                  "id": "LozLXzJSIyXk",
+                  "ref": "f42fd9c4-bb4e-49fa-8438-d607f105e284",
+                  "label": "Oral prescriptions pills (Montelukast/Singulair)"
+                },
+                {
+                  "id": "erfBQS3JZjrv",
+                  "ref": "82168fab-b4b5-4b34-8c3a-3db5e913a1fa",
+                  "label": "Nasal sprays (Flonase, Nasonex, etc)"
+                },
+                {
+                  "id": "VAOKxywANPgv",
+                  "ref": "83d3e5d9-296b-4dfc-ba34-f9fe196fd9d7",
+                  "label": "Nasal rinses, irrigation, Netti pot, etc."
+                },
+                {
+                  "id": "Seg9t5VkwlZ0",
+                  "ref": "110be969-8235-4187-ab29-f3f02e36c802",
+                  "label": "Allergy shots/injections"
+                },
+                {
+                  "id": "uZB71fmx0Pxj",
+                  "ref": "ea8865ff-ff9f-48c2-a26a-f7e365e3d3fb",
+                  "label": "Nothing, no treatments"
+                },
+                {
+                  "id": "jqImdmmNMG6C",
+                  "ref": "11b40126-d4b5-4048-af60-bcb94eaffa8a",
+                  "label": "Other"
+                }
+              ]
+            },
+            "validations": {
+              "required": true
+            },
+            "type": "multiple_choice"
+          },
+          {
+            "id": "ieqirdVE4nxf",
+            "title": "Please share more details about treatments:",
+            "ref": "8bb07475-f826-4617-8d0b-878293ce96d5",
+            "properties": {},
+            "validations": {
+              "required": false
+            },
+            "type": "short_text"
+          },
+          {
+            "id": "18jqQF69goP4",
+            "title": "Is there another chronic condition you wanted to discuss that wasn't specifically asked about?",
+            "ref": "c02bf04c-c772-43f9-9743-e088ea96fd39",
+            "properties": {},
+            "validations": {
+              "required": false
+            },
+            "type": "yes_no"
+          },
+          {
+            "id": "mpF1jE5HXhBk",
+            "title": "Please share the condition and details:",
+            "ref": "5dea4979-aeb1-4aca-ac27-d4022f5cf4fa",
+            "properties": {},
+            "validations": {
+              "required": true
+            },
+            "type": "long_text"
+          }
+        ]
+      },
+      "type": "group"
+    },
+    {
+      "id": "aCziwy60YWIH",
+      "title": "Acute Condition Follow-Up",
+      "ref": "73fba634-e2ec-443f-a314-2c1e48949b3b",
+      "properties": {
+        "button_text": "Continue",
+        "show_button": false,
+        "fields": [
+          {
+            "id": "ZcPrWGbPdKrG",
+            "title": "Which of the following issues best describe what you were seen for previously?",
+            "ref": "9b9752ce-701d-4861-902f-514b0568b463",
+            "properties": {
+              "randomize": false,
+              "allow_multiple_selection": false,
+              "allow_other_choice": false,
+              "vertical_alignment": true,
+              "choices": [
+                {
+                  "id": "Fw1ChDXA8m4H",
+                  "ref": "257e99a8-823b-47bd-9871-3a5833644f07",
+                  "label": "Allergies (Seasonal / Allergic Rhinitis)"
+                },
+                {
+                  "id": "wzCUcoVKPTNo",
+                  "ref": "07741527-acd0-463c-8b8d-61b5dcca229c",
+                  "label": "Bladder Infection / Urinary Tract Infection Symptoms"
+                },
+                {
+                  "id": "6KBpEj8T6Rtp",
+                  "ref": "3da834c0-a5be-410f-896c-37bb0b7fff31",
+                  "label": "Cough, Cold, or Respiratory Flu (breathing/lung) concerns"
+                },
+                {
+                  "id": "07fBFYEejclf",
+                  "ref": "77d93d70-fe35-4152-8f39-c02e8d0a7614",
+                  "label": "Ear Pain or other Ear Concern"
+                },
+                {
+                  "id": "EvVVBUgwGcWI",
+                  "ref": "8209cfcd-c77f-4abb-8ba4-75cf014e9936",
+                  "label": "Rash or other Skin Concern"
+                },
+                {
+                  "id": "jqIO7n9eoZyo",
+                  "ref": "eb0057b4-c265-4449-a340-7c0921f06c5e",
+                  "label": "Sinus Symptoms"
+                },
+                {
+                  "id": "2bYi9eZGdFdq",
+                  "ref": "2d7daaa2-ab38-44ac-af6f-75dc93b2e867",
+                  "label": "Sore Throat"
+                },
+                {
+                  "id": "YKc4EtjpIyBo",
+                  "ref": "1414c57b-5b2e-4bbb-b1a0-5d74be4fe289",
+                  "label": "Vaginal Yeast or Bacterial Infection Symptoms"
+                },
+                {
+                  "id": "jAF8dvFaZiQ2",
+                  "ref": "e1f58849-7688-44ad-b23d-2d77620fa8f4",
+                  "label": "Conjunctivitis \"Pink Eye\" or Stye Symptoms"
+                },
+                {
+                  "id": "rjLvoty4t4Di",
+                  "ref": "40857c0e-7021-49bb-bf8d-50a0fbd69388",
+                  "label": "Other"
+                }
+              ]
+            },
+            "validations": {
+              "required": true
+            },
+            "type": "multiple_choice"
+          },
+          {
+            "id": "mi76eh0WPCw0",
+            "title": "Please share more details about why you were previously seen:",
+            "ref": "ade5c304-a9cb-44a0-8e99-3be05f7c6ca4",
+            "properties": {},
+            "validations": {
+              "required": false
+            },
+            "type": "short_text"
+          },
+          {
+            "id": "XXCEzgFp1nYA",
+            "title": "Are you having new symptoms or worsening of the symptoms you discussed with your Specialty provider?",
+            "ref": "48f171fb-1987-4fec-9587-cfd53aaf5215",
+            "properties": {},
+            "validations": {
+              "required": false
+            },
+            "type": "yes_no"
+          },
+          {
+            "id": "LEcZdf93JMLq",
+            "title": "Please share more details with your Specialty Healthcare team today: ",
+            "ref": "12b4401d-435e-4e89-82ff-8a26d312bcc6",
+            "properties": {},
+            "validations": {
+              "required": false
+            },
+            "type": "long_text"
+          }
+        ]
+      },
+      "type": "group"
+    },
+    {
+      "id": "FTCZQudk5nuR",
+      "title": "Wellness \u0026 Prevention Visits",
+      "ref": "292739bb-a016-4b42-b67b-5329b9a700ae",
+      "properties": {
+        "button_text": "Continue",
+        "show_button": true,
+        "fields": [
+          {
+            "id": "d1FWyG4wsxAx",
+            "title": "Is this visit an employer-sponsored wellness program requirement?",
+            "ref": "25a9c133-1ad8-4e0e-b173-85415fab36c1",
+            "properties": {},
+            "validations": {
+              "required": true
+            },
+            "type": "yes_no"
+          },
+          {
+            "id": "aEF6rqQQViZJ",
+            "title": "By typing my name below, I consent to Specialty Healthcare informing my employer that I fulfilled the wellness/biometric visit requirement. Further, I consent to Specialty Healthcare sharing my biometric data with my health insurance carrier in order to obtain an incentive.",
+            "ref": "1324a6cb-0a8a-4684-86fb-b3732d83ad29",
+            "properties": {},
+            "validations": {
+              "required": true
+            },
+            "type": "short_text"
+          },
+          {
+            "id": "tvYNGnrQWcZN",
+            "title": "When did you have your last complete physical exam?",
+            "ref": "62bbe9cc-c797-4b7a-ad1d-d4328f7f8589",
+            "properties": {
+              "separator": "/",
+              "structure": "MMDDYYYY"
+            },
+            "validations": {
+              "required": false
+            },
+            "type": "date"
+          },
+          {
+            "id": "QFa98j3lZcYD",
+            "title": "What type of wellness or prevention best describes your visit?",
+            "ref": "8beed41c-a740-4a05-8a7f-7057266d5822",
+            "properties": {
+              "randomize": false,
+              "allow_multiple_selection": false,
+              "allow_other_choice": false,
+              "vertical_alignment": true,
+              "choices": [
+                {
+                  "id": "g1lTsErS3De7",
+                  "ref": "81ae5edc-6a5c-4a26-85ac-4cf00b4b8329",
+                  "label": "Annual Physical"
+                },
+                {
+                  "id": "FAJw9FQIrHZ5",
+                  "ref": "389be09e-3eaf-4fe0-80aa-c961744a63d3",
+                  "label": "Contraception"
+                },
+                {
+                  "id": "HNK3eSmhYU3h",
+                  "ref": "d32588fd-681f-4d40-b0bc-0ed1cb4ac1bb",
+                  "label": "Wellness Coaching"
+                }
+              ]
+            },
+            "validations": {
+              "required": true
+            },
+            "type": "multiple_choice"
+          },
+          {
+            "id": "tCUH2ttgpE2X",
+            "title": "How would you best describe your immunization (vaccine) status?",
+            "ref": "f69d08b4-ad76-489a-9623-efb21ae5320d",
+            "properties": {
+              "randomize": false,
+              "allow_multiple_selection": false,
+              "allow_other_choice": false,
+              "vertical_alignment": true,
+              "choices": [
+                {
+                  "id": "gcy2LvetHC44",
+                  "ref": "e7f473cd-6603-4703-b538-eb7d49aae19f",
+                  "label": "I don't know if I am up to date"
+                },
+                {
+                  "id": "5VwYkQHldghi",
+                  "ref": "df136e1a-3a57-4e42-8c82-c61b1366d73e",
+                  "label": "I am up to date"
+                },
+                {
+                  "id": "mWzuxXAqFzoY",
+                  "ref": "ae3cce39-0fdf-4e25-b132-2dcc292108c6",
+                  "label": "I believe that I am due for immunization(s)/vaccine(s)"
+                },
+                {
+                  "id": "4fxVZ8k4WFmz",
+                  "ref": "a0c17f07-5e33-499f-ba7f-2cec27c736b1",
+                  "label": "I am not up to date on my immunizations/vaccines but I do not choose to receive vaccines"
+                }
+              ]
+            },
+            "validations": {
+              "required": false
+            },
+            "type": "multiple_choice"
+          }
+        ]
+      },
+      "type": "group"
+    },
+    {
+      "id": "5l0hVNfLcyRG",
+      "title": "Contraception Check-In",
+      "ref": "2f49a384-a78f-4742-ac4b-dd13432348ca",
+      "properties": {
+        "button_text": "Continue",
+        "show_button": false,
+        "fields": [
+          {
+            "id": "qCSF4r7rzhWQ",
+            "title": "What is your primary reason for checking in with your provider?",
+            "ref": "203fddfa-b4bd-4520-b100-7e87f725be6d",
+            "properties": {
+              "randomize": false,
+              "allow_multiple_selection": true,
+              "allow_other_choice": false,
+              "vertical_alignment": true,
+              "choices": [
+                {
+                  "id": "0cSL1KT05MKe",
+                  "ref": "521bab03-1002-4fc6-9558-57a3fd871ccc",
+                  "label": "Things are going well and I'd like to continue with my current birth control"
+                },
+                {
+                  "id": "6YNp8Vildfq4",
+                  "ref": "c41d2fc3-d5b8-490b-a8b1-f47c5d3eab85",
+                  "label": "I have questions/concerns about my current birth control"
+                },
+                {
+                  "id": "CQVvfpxrkwFT",
+                  "ref": "f09e0f76-4508-4dbf-af0a-25fb6aa71236",
+                  "label": "I'd like to discuss other birth control options"
+                },
+                {
+                  "id": "N0xyxKcv33EP",
+                  "ref": "e78154b3-5589-40c6-8de4-2e9472198f15",
+                  "label": "Other"
+                }
+              ]
+            },
+            "validations": {
+              "required": false
+            },
+            "type": "multiple_choice"
+          },
+          {
+            "id": "8xMox7JT0tQO",
+            "title": "What other reason did you want to check-in?",
+            "ref": "6c26f08e-cbbd-4f94-83bb-2cac1106e998",
+            "properties": {},
+            "validations": {
+              "required": false
+            },
+            "type": "short_text"
+          },
+          {
+            "id": "WRET7cRohYQQ",
+            "title": "Please share any additional details about how things are going (well or otherwise) with your medical provider:",
+            "ref": "64c3f569-5517-41be-ab9f-d5f1b2255e2c",
+            "properties": {},
+            "validations": {
+              "required": false
+            },
+            "type": "long_text"
+          }
+        ]
+      },
+      "type": "group"
+    },
+    {
+      "id": "XHegwrWY0Mec",
+      "title": "Wellness Coaching ",
+      "ref": "286c5a9a-4636-4c29-9227-77f081c5e5f9",
+      "properties": {
+        "button_text": "Continue",
+        "show_button": false,
+        "fields": [
+          {
+            "id": "IlXZ5X1FN6mO",
+            "title": "What is your number one goal related to your health?",
+            "ref": "dd69dc04-dea0-4f76-b880-ed16bebee4a4",
+            "properties": {},
+            "validations": {
+              "required": false
+            },
+            "type": "short_text"
+          }
+        ]
+      },
+      "type": "group"
+    },
+    {
+      "id": "ZWwEFMdhKVoE",
+      "title": "Wellness Check-In",
+      "ref": "9aa62841-1faf-4cec-ad87-1bf32233bb4d",
+      "properties": {
+        "button_text": "Continue",
+        "show_button": false,
+        "fields": [
+          {
+            "id": "hHL75uUgHnim",
+            "title": "We are looking forward to your update and commend you on continuing to work toward your goals in the pursuit of wellness.",
+            "ref": "070dd1c6-4e1e-4464-985e-83949c8d0eea",
+            "properties": {
+              "button_text": "Continue",
+              "hide_marks": false
+            },
+            "type": "statement"
+          },
+          {
+            "id": "JFiWDh7nCtDe",
+            "title": "What steps have you taken toward your chosen primary health goal?",
+            "ref": "e7e62496-6253-4887-9164-01cbc41aae54",
+            "properties": {},
+            "validations": {
+              "required": false
+            },
+            "type": "long_text"
+          }
+        ]
+      },
+      "type": "group"
+    },
+    {
+      "id": "zP2nwnon2siA",
+      "title": "General Chronic and Wellness Questions",
+      "ref": "2d31b2fd-3572-4056-9eeb-a19889e664e6",
+      "properties": {
+        "button_text": "Continue",
+        "show_button": true,
+        "fields": [
+          {
+            "id": "6px6xW8awQi7",
+            "title": "How tall are you?",
+            "ref": "3e8760df-4a6e-47f2-8b03-0ef2e72ac35f",
+            "properties": {
+              "description": "list in inches please"
+            },
+            "validations": {
+              "required": false
+            },
+            "type": "number"
+          },
+          {
+            "id": "m8w9W9QaJf1b",
+            "title": "What was your most recent weight?",
+            "ref": "71754c21-d349-4d31-b2d9-a6429910d594",
+            "properties": {
+              "description": "list in pounds please"
+            },
+            "validations": {
+              "required": false
+            },
+            "type": "number"
+          },
+          {
+            "id": "U3o5oeBDiHpX",
+            "title": "Please share your typical daily diet:",
+            "ref": "f750e6d0-cf39-453d-8020-385bf8d6990c",
+            "properties": {
+              "description": "Include any special diets, meal patterns, etc. You may skip if you've already answered elsewhere."
+            },
+            "validations": {
+              "required": false
+            },
+            "type": "short_text"
+          },
+          {
+            "id": "owKXXnomaPfN",
+            "title": "Select the following that best describes your typical level of activity:",
+            "ref": "4d2a4bca-54db-4f93-ad23-47ecd998acf4",
+            "properties": {
+              "randomize": false,
+              "allow_multiple_selection": true,
+              "allow_other_choice": false,
+              "vertical_alignment": true,
+              "choices": [
+                {
+                  "id": "yTlTTOxcZcF3",
+                  "ref": "e9613640-e633-450d-a63b-a8ed48690a75",
+                  "label": "I am mostly sedentary"
+                },
+                {
+                  "id": "QOYfVpsJLLRu",
+                  "ref": "0fed27fa-f05f-499d-a9bd-cf9d3c1c3bb3",
+                  "label": "I walk for 30 minutes or less some days of the week"
+                },
+                {
+                  "id": "3ciq1gL3pmcQ",
+                  "ref": "84dd494a-f1c4-48da-a6c1-8f4707eb5d4c",
+                  "label": "I walk for 30 minutes or more at least 3 days of the week"
+                },
+                {
+                  "id": "2NOkzz5yemkb",
+                  "ref": "ddcc8b86-be2e-416b-bd09-d6d2648d1515",
+                  "label": "I exercise vigorously 3 or more days per week"
+                },
+                {
+                  "id": "1fmeDpMMHSEU",
+                  "ref": "3c1ee90f-e534-4e61-a554-9d4492e8fbc2",
+                  "label": "I lift weights or do other strength training 2-3 days per week"
+                },
+                {
+                  "id": "ihozJSjF5xXN",
+                  "ref": "18617627-f13e-4d41-acfb-be50e66dc09b",
+                  "label": "Other"
+                }
+              ]
+            },
+            "validations": {
+              "required": false
+            },
+            "type": "multiple_choice"
+          },
+          {
+            "id": "1jZg4MllKKec",
+            "title": "Please share more details about your physical activity:",
+            "ref": "0fb424e0-7d13-4d80-83c3-3403a4816eba",
+            "properties": {},
+            "validations": {
+              "required": false
+            },
+            "type": "short_text"
+          }
+        ]
+      },
+      "type": "group"
+    },
+    {
+      "id": "yqLB99JS0G3s",
+      "title": "In Person and/or Medication Delivery Pre-Visit Information",
+      "ref": "641d40e1-c989-4127-84bd-29aaf3a7ff52",
+      "properties": {
+        "button_text": "Continue",
+        "show_button": false,
+        "fields": [
+          {
+            "id": "uyqXUHSzflEF",
+            "title": "What is your preferred pharmacy name and address?",
+            "ref": "391758e5-f1d3-4d06-b217-a009e7cf0f7f",
+            "properties": {
+              "description": "(Note: the Specialty Pharmacy Card, which offers you many medications for free, is NOT accepted at Walgreens)"
+            },
+            "validations": {
+              "required": false
+            },
+            "type": "short_text"
+          }
+        ]
+      },
+      "type": "group"
+    }
+  ],
+  "hidden": [
+    "patientid",
+    "sixty_five_plus_eligible"
+  ],
+  "logic": [
+    {
+      "type": "field",
+      "ref": "42aedcc2-af25-4016-9f17-d521007c3a2f",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "3d9c7bec-b7f9-4760-bc16-6312b95f677d"
+            }
+          },
+          "condition": {
+            "op": "is",
+            "vars": [
+              {
+                "type": "field",
+                "value": "42aedcc2-af25-4016-9f17-d521007c3a2f"
+              },
+              {
+                "type": "constant",
+                "value": true
+              }
+            ]
+          }
+        },
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "6f999cc5-0c01-41e1-82f5-8d1eaf127ae5"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "field",
+      "ref": "bc8dffad-347b-472c-a9c0-1eb8986e12d6",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "31800457-2f96-4552-a3c2-b4e8420d5f5b"
+            }
+          },
+          "condition": {
+            "op": "or",
+            "vars": [
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "4915db69-55ca-4a00-b57e-893d7ea3e761"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "2f202927-97b2-4d9c-aaef-1296fb68c5ba"
+                  }
+                ]
+              },
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "4915db69-55ca-4a00-b57e-893d7ea3e761"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "e6a75660-04b1-445a-bdd4-13b95e5a2114"
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "02115986-9afa-4581-90a7-d3d4b994129e"
+            }
+          },
+          "condition": {
+            "op": "and",
+            "vars": [
+              {
+                "op": "is_not",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "4915db69-55ca-4a00-b57e-893d7ea3e761"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "2f202927-97b2-4d9c-aaef-1296fb68c5ba"
+                  }
+                ]
+              },
+              {
+                "op": "is_not",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "4915db69-55ca-4a00-b57e-893d7ea3e761"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "e6a75660-04b1-445a-bdd4-13b95e5a2114"
+                  }
+                ]
+              },
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "c09778dd-d584-40cc-8517-a627592ca5f1"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "afd3955c-0510-4df4-9ba5-1f6603f1436e"
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "799863f0-b4fe-4267-97c0-05292c88a926"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "field",
+      "ref": "9e625f22-ee19-4492-9897-97e8375258fb",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "82c36b8e-e4ed-4b1c-81b1-f0ece0b53865"
+            }
+          },
+          "condition": {
+            "op": "is",
+            "vars": [
+              {
+                "type": "field",
+                "value": "9e625f22-ee19-4492-9897-97e8375258fb"
+              },
+              {
+                "type": "constant",
+                "value": true
+              }
+            ]
+          }
+        },
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "76aea2fa-cba3-400a-b0d8-485416241861"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "field",
+      "ref": "4915db69-55ca-4a00-b57e-893d7ea3e761",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "f4040a6a-7c46-4f22-a659-61bf9c713cdc"
+            }
+          },
+          "condition": {
+            "op": "is",
+            "vars": [
+              {
+                "type": "field",
+                "value": "4915db69-55ca-4a00-b57e-893d7ea3e761"
+              },
+              {
+                "type": "choice",
+                "value": "2f202927-97b2-4d9c-aaef-1296fb68c5ba"
+              }
+            ]
+          }
+        },
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "f55dd9ee-6bcd-4438-b61a-9766e38da976"
+            }
+          },
+          "condition": {
+            "op": "is",
+            "vars": [
+              {
+                "type": "field",
+                "value": "4915db69-55ca-4a00-b57e-893d7ea3e761"
+              },
+              {
+                "type": "choice",
+                "value": "e6a75660-04b1-445a-bdd4-13b95e5a2114"
+              }
+            ]
+          }
+        },
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "c09778dd-d584-40cc-8517-a627592ca5f1"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "field",
+      "ref": "bb4445c2-e5fb-43b4-904e-2b18225319ba",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "42aedcc2-af25-4016-9f17-d521007c3a2f"
+            }
+          },
+          "condition": {
+            "op": "is",
+            "vars": [
+              {
+                "type": "field",
+                "value": "bb4445c2-e5fb-43b4-904e-2b18225319ba"
+              },
+              {
+                "type": "choice",
+                "value": "9c02faba-8a92-4431-9c4c-12da6322536c"
+              }
+            ]
+          }
+        },
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "39b2633b-7d5d-4f2f-b92a-be6101ec91d8"
+            }
+          },
+          "condition": {
+            "op": "is",
+            "vars": [
+              {
+                "type": "field",
+                "value": "bb4445c2-e5fb-43b4-904e-2b18225319ba"
+              },
+              {
+                "type": "choice",
+                "value": "6a4b2f33-2c83-4976-a341-a2eb81f2fc6e"
+              }
+            ]
+          }
+        },
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "5102aafe-809a-4977-b18e-e9037af84575"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "field",
+      "ref": "c09778dd-d584-40cc-8517-a627592ca5f1",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "778d214e-b9e1-4fca-a0ed-922369858b36"
+            }
+          },
+          "condition": {
+            "op": "and",
+            "vars": [
+              {
+                "op": "is_not",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "4915db69-55ca-4a00-b57e-893d7ea3e761"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "e6a75660-04b1-445a-bdd4-13b95e5a2114"
+                  }
+                ]
+              },
+              {
+                "op": "is_not",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "4915db69-55ca-4a00-b57e-893d7ea3e761"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "2f202927-97b2-4d9c-aaef-1296fb68c5ba"
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "5db25282-6779-46dd-8667-ea52a630056a"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "field",
+      "ref": "ae1d9d32-1296-4b52-bfb0-2e153756d551",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "f443be96-e76a-4615-af32-bcf92d5d4831"
+            }
+          },
+          "condition": {
+            "op": "is",
+            "vars": [
+              {
+                "type": "field",
+                "value": "ae1d9d32-1296-4b52-bfb0-2e153756d551"
+              },
+              {
+                "type": "constant",
+                "value": true
+              }
+            ]
+          }
+        },
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "396ddc90-a1f2-4268-b7f0-f4491331b256"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "field",
+      "ref": "7f57a989-19d3-40b8-af66-d022d3ebb73f",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "02115986-9afa-4581-90a7-d3d4b994129e"
+            }
+          },
+          "condition": {
+            "op": "and",
+            "vars": [
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "7f57a989-19d3-40b8-af66-d022d3ebb73f"
+                  },
+                  {
+                    "type": "constant",
+                    "value": true
+                  }
+                ]
+              },
+              {
+                "op": "is_not",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "4915db69-55ca-4a00-b57e-893d7ea3e761"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "2f202927-97b2-4d9c-aaef-1296fb68c5ba"
+                  }
+                ]
+              },
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "c09778dd-d584-40cc-8517-a627592ca5f1"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "afd3955c-0510-4df4-9ba5-1f6603f1436e"
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "5d99768b-65af-4f68-9939-87dfbd29f49a"
+            }
+          },
+          "condition": {
+            "op": "is",
+            "vars": [
+              {
+                "type": "field",
+                "value": "7f57a989-19d3-40b8-af66-d022d3ebb73f"
+              },
+              {
+                "type": "constant",
+                "value": true
+              }
+            ]
+          }
+        },
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "09c640b9-37b7-452e-a5a8-f2db8d0fda12"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "field",
+      "ref": "c080588e-4846-4c28-8aa8-3a564d02d2e2",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "1232777d-45f5-424e-b972-0c988e8a03fd"
+            }
+          },
+          "condition": {
+            "op": "is",
+            "vars": [
+              {
+                "type": "field",
+                "value": "c080588e-4846-4c28-8aa8-3a564d02d2e2"
+              },
+              {
+                "type": "constant",
+                "value": true
+              }
+            ]
+          }
+        },
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "02115986-9afa-4581-90a7-d3d4b994129e"
+            }
+          },
+          "condition": {
+            "op": "and",
+            "vars": [
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "c080588e-4846-4c28-8aa8-3a564d02d2e2"
+                  },
+                  {
+                    "type": "constant",
+                    "value": false
+                  }
+                ]
+              },
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "4915db69-55ca-4a00-b57e-893d7ea3e761"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "e6a75660-04b1-445a-bdd4-13b95e5a2114"
+                  }
+                ]
+              },
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "c09778dd-d584-40cc-8517-a627592ca5f1"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "afd3955c-0510-4df4-9ba5-1f6603f1436e"
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "aea7a268-64d4-4f16-920a-b9afe317e3b6"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "field",
+      "ref": "371ccee2-c490-4b87-a435-814ca6daed79",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "381198f4-0c79-4289-bf68-a3c55352baae"
+            }
+          },
+          "condition": {
+            "op": "is",
+            "vars": [
+              {
+                "type": "field",
+                "value": "371ccee2-c490-4b87-a435-814ca6daed79"
+              },
+              {
+                "type": "constant",
+                "value": true
+              }
+            ]
+          }
+        },
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "9e625f22-ee19-4492-9897-97e8375258fb"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "field",
+      "ref": "0b46777e-7166-4d32-bdde-71ee31fb8a20",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "3f3bba87-b210-43c0-bb79-b19a889f7899"
+            }
+          },
+          "condition": {
+            "op": "or",
+            "vars": [
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "0b46777e-7166-4d32-bdde-71ee31fb8a20"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "d6afcaa8-2bbf-4c0b-91bd-43c2253ddf8c"
+                  }
+                ]
+              },
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "0b46777e-7166-4d32-bdde-71ee31fb8a20"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "1c1b2204-a63b-4c53-ac3c-839c867e6d33"
+                  }
+                ]
+              },
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "0b46777e-7166-4d32-bdde-71ee31fb8a20"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "8337d5c1-29d2-4103-a2fe-c5b19cacff6a"
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "527c054c-6f32-4c81-aa5e-23411da3682d"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "field",
+      "ref": "5d99768b-65af-4f68-9939-87dfbd29f49a",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "d507cc27-5716-4b21-ae06-abaa5a55ee19"
+            }
+          },
+          "condition": {
+            "op": "is",
+            "vars": [
+              {
+                "type": "field",
+                "value": "5d99768b-65af-4f68-9939-87dfbd29f49a"
+              },
+              {
+                "type": "constant",
+                "value": true
+              }
+            ]
+          }
+        },
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "aea7a268-64d4-4f16-920a-b9afe317e3b6"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "field",
+      "ref": "4367ffe0-1053-4a6e-9f50-b5e66da908cd",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "4980325d-2ecf-413f-b978-1270dc707c79"
+            }
+          },
+          "condition": {
+            "op": "is",
+            "vars": [
+              {
+                "type": "field",
+                "value": "4367ffe0-1053-4a6e-9f50-b5e66da908cd"
+              },
+              {
+                "type": "constant",
+                "value": true
+              }
+            ]
+          }
+        },
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "aea7a268-64d4-4f16-920a-b9afe317e3b6"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "field",
+      "ref": "97906f9c-408e-4043-9add-e36680708e95",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "799863f0-b4fe-4267-97c0-05292c88a926"
+            }
+          },
+          "condition": {
+            "op": "and",
+            "vars": [
+              {
+                "op": "is_not",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "4915db69-55ca-4a00-b57e-893d7ea3e761"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "2f202927-97b2-4d9c-aaef-1296fb68c5ba"
+                  }
+                ]
+              },
+              {
+                "op": "is_not",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "4915db69-55ca-4a00-b57e-893d7ea3e761"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "e6a75660-04b1-445a-bdd4-13b95e5a2114"
+                  }
+                ]
+              },
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "7f57a989-19d3-40b8-af66-d022d3ebb73f"
+                  },
+                  {
+                    "type": "constant",
+                    "value": false
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "aea7a268-64d4-4f16-920a-b9afe317e3b6"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "field",
+      "ref": "6f999cc5-0c01-41e1-82f5-8d1eaf127ae5",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "a6521f1c-0bcc-4163-9373-c286a34dd2ca"
+            }
+          },
+          "condition": {
+            "op": "is",
+            "vars": [
+              {
+                "type": "field",
+                "value": "6f999cc5-0c01-41e1-82f5-8d1eaf127ae5"
+              },
+              {
+                "type": "constant",
+                "value": true
+              }
+            ]
+          }
+        },
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "cb42a04e-04e6-40c3-b96a-33cc66c2f02f"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "field",
+      "ref": "1232777d-45f5-424e-b972-0c988e8a03fd",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "02115986-9afa-4581-90a7-d3d4b994129e"
+            }
+          },
+          "condition": {
+            "op": "and",
+            "vars": [
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "4915db69-55ca-4a00-b57e-893d7ea3e761"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "e6a75660-04b1-445a-bdd4-13b95e5a2114"
+                  }
+                ]
+              },
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "c09778dd-d584-40cc-8517-a627592ca5f1"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "afd3955c-0510-4df4-9ba5-1f6603f1436e"
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "aea7a268-64d4-4f16-920a-b9afe317e3b6"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "field",
+      "ref": "cb42a04e-04e6-40c3-b96a-33cc66c2f02f",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "15e1a76c-e053-47bc-9b5b-2ce0682684dc"
+            }
+          },
+          "condition": {
+            "op": "is",
+            "vars": [
+              {
+                "type": "field",
+                "value": "cb42a04e-04e6-40c3-b96a-33cc66c2f02f"
+              },
+              {
+                "type": "constant",
+                "value": true
+              }
+            ]
+          }
+        },
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "bc8dffad-347b-472c-a9c0-1eb8986e12d6"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "field",
+      "ref": "4980325d-2ecf-413f-b978-1270dc707c79",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "be288874-040c-4223-8861-001d42f2e8a6"
+            }
+          },
+          "condition": {
+            "op": "is",
+            "vars": [
+              {
+                "type": "field",
+                "value": "4980325d-2ecf-413f-b978-1270dc707c79"
+              },
+              {
+                "type": "choice",
+                "value": "f179dda3-3f7b-4ae0-866a-1481c4b6cda9"
+              }
+            ]
+          }
+        },
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "aea7a268-64d4-4f16-920a-b9afe317e3b6"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "field",
+      "ref": "78402997-6809-4f34-90bd-7eac13159171",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "acedb884-d985-4b8d-a70d-8b2948409a79"
+            }
+          },
+          "condition": {
+            "op": "is",
+            "vars": [
+              {
+                "type": "field",
+                "value": "78402997-6809-4f34-90bd-7eac13159171"
+              },
+              {
+                "type": "constant",
+                "value": true
+              }
+            ]
+          }
+        },
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "257b5962-e30b-4d1f-b752-e4abca0a570d"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "field",
+      "ref": "257b5962-e30b-4d1f-b752-e4abca0a570d",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "33c73ff7-fa6b-40f4-90cb-5e6488ea6ac5"
+            }
+          },
+          "condition": {
+            "op": "is",
+            "vars": [
+              {
+                "type": "field",
+                "value": "257b5962-e30b-4d1f-b752-e4abca0a570d"
+              },
+              {
+                "type": "constant",
+                "value": true
+              }
+            ]
+          }
+        },
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "3f7cdb5c-ebb2-4ea8-9e05-c36400f5380a"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "field",
+      "ref": "3f7cdb5c-ebb2-4ea8-9e05-c36400f5380a",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "7af3eb65-dda9-4ce8-8049-770e4d6cd786"
+            }
+          },
+          "condition": {
+            "op": "is",
+            "vars": [
+              {
+                "type": "field",
+                "value": "3f7cdb5c-ebb2-4ea8-9e05-c36400f5380a"
+              },
+              {
+                "type": "constant",
+                "value": true
+              }
+            ]
+          }
+        },
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "5c96ea8f-3f79-4784-af6f-a2f63cc4dc5d"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "field",
+      "ref": "5c96ea8f-3f79-4784-af6f-a2f63cc4dc5d",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "87ab4476-c084-41b5-8add-8d8e26e5d4f8"
+            }
+          },
+          "condition": {
+            "op": "is",
+            "vars": [
+              {
+                "type": "field",
+                "value": "5c96ea8f-3f79-4784-af6f-a2f63cc4dc5d"
+              },
+              {
+                "type": "constant",
+                "value": true
+              }
+            ]
+          }
+        },
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "481bb5f7-22cc-4ba3-a29f-1803c33c65b5"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "field",
+      "ref": "481bb5f7-22cc-4ba3-a29f-1803c33c65b5",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "6b65383a-8e48-4e6f-bdd9-e41893a18677"
+            }
+          },
+          "condition": {
+            "op": "is",
+            "vars": [
+              {
+                "type": "field",
+                "value": "481bb5f7-22cc-4ba3-a29f-1803c33c65b5"
+              },
+              {
+                "type": "constant",
+                "value": true
+              }
+            ]
+          }
+        },
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "a07cfd6c-5947-4db1-ae11-08018c55cb34"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "field",
+      "ref": "a07cfd6c-5947-4db1-ae11-08018c55cb34",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "a743e9a4-7d57-4e6a-9815-d84a4f5d556a"
+            }
+          },
+          "condition": {
+            "op": "is",
+            "vars": [
+              {
+                "type": "field",
+                "value": "a07cfd6c-5947-4db1-ae11-08018c55cb34"
+              },
+              {
+                "type": "constant",
+                "value": true
+              }
+            ]
+          }
+        },
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "b045eb9e-65f4-4685-a416-ea0d64ead194"
+            }
+          },
+          "condition": {
+            "op": "and",
+            "vars": [
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "a07cfd6c-5947-4db1-ae11-08018c55cb34"
+                  },
+                  {
+                    "type": "constant",
+                    "value": false
+                  }
+                ]
+              },
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "481bb5f7-22cc-4ba3-a29f-1803c33c65b5"
+                  },
+                  {
+                    "type": "constant",
+                    "value": true
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "a099c975-05d2-4368-8ead-8b0ca02cdbf9"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "field",
+      "ref": "c02bf04c-c772-43f9-9743-e088ea96fd39",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "5dea4979-aeb1-4aca-ac27-d4022f5cf4fa"
+            }
+          },
+          "condition": {
+            "op": "is",
+            "vars": [
+              {
+                "type": "field",
+                "value": "c02bf04c-c772-43f9-9743-e088ea96fd39"
+              },
+              {
+                "type": "constant",
+                "value": true
+              }
+            ]
+          }
+        },
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "3e8760df-4a6e-47f2-8b03-0ef2e72ac35f"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "field",
+      "ref": "d7f05a87-e981-403b-8113-ddba96ad4160",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "58af010f-e909-49c2-a4ed-8497364593b8"
+            }
+          },
+          "condition": {
+            "op": "is",
+            "vars": [
+              {
+                "type": "field",
+                "value": "d7f05a87-e981-403b-8113-ddba96ad4160"
+              },
+              {
+                "type": "constant",
+                "value": true
+              }
+            ]
+          }
+        },
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "58d9fbe4-7e9f-4da9-aafc-f3b36e747533"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "field",
+      "ref": "58af010f-e909-49c2-a4ed-8497364593b8",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "1d2f2106-0c46-46cc-ae52-e599c9d2f511"
+            }
+          },
+          "condition": {
+            "op": "is",
+            "vars": [
+              {
+                "type": "field",
+                "value": "58af010f-e909-49c2-a4ed-8497364593b8"
+              },
+              {
+                "type": "choice",
+                "value": "b68731e6-bfbd-4588-bf69-57458eb9ec4c"
+              }
+            ]
+          }
+        },
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "58d9fbe4-7e9f-4da9-aafc-f3b36e747533"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "field",
+      "ref": "a0c4a70d-17bf-40e8-a0a2-9e4be165177f",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "657aa9f8-04df-42b5-ad40-e410e31149f4"
+            }
+          },
+          "condition": {
+            "op": "is",
+            "vars": [
+              {
+                "type": "field",
+                "value": "a0c4a70d-17bf-40e8-a0a2-9e4be165177f"
+              },
+              {
+                "type": "constant",
+                "value": true
+              }
+            ]
+          }
+        },
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "ae1d9d32-1296-4b52-bfb0-2e153756d551"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "field",
+      "ref": "a099c975-05d2-4368-8ead-8b0ca02cdbf9",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "7d78fe9a-8a68-42e9-a732-46e8a24ac379"
+            }
+          },
+          "condition": {
+            "op": "is",
+            "vars": [
+              {
+                "type": "field",
+                "value": "a099c975-05d2-4368-8ead-8b0ca02cdbf9"
+              },
+              {
+                "type": "constant",
+                "value": true
+              }
+            ]
+          }
+        },
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "c02bf04c-c772-43f9-9743-e088ea96fd39"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "field",
+      "ref": "daab8076-557d-4572-a489-14d08038ff4b",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "c5a79da8-d8f4-4250-9a4a-169d1af7e805"
+            }
+          },
+          "condition": {
+            "op": "is",
+            "vars": [
+              {
+                "type": "field",
+                "value": "daab8076-557d-4572-a489-14d08038ff4b"
+              },
+              {
+                "type": "constant",
+                "value": true
+              }
+            ]
+          }
+        },
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "a099c975-05d2-4368-8ead-8b0ca02cdbf9"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "field",
+      "ref": "657aa9f8-04df-42b5-ad40-e410e31149f4",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "fa2f6cf9-13ff-4c73-9f29-40a0b986f3b8"
+            }
+          },
+          "condition": {
+            "op": "is",
+            "vars": [
+              {
+                "type": "field",
+                "value": "657aa9f8-04df-42b5-ad40-e410e31149f4"
+              },
+              {
+                "type": "choice",
+                "value": "30736abf-3f93-4a95-ba99-0f69e1aab529"
+              }
+            ]
+          }
+        },
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "ae1d9d32-1296-4b52-bfb0-2e153756d551"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "field",
+      "ref": "29c950ea-e45e-4838-a07b-3b640095c940",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "3bdc4355-214a-4c3e-9220-e49cb136845c"
+            }
+          },
+          "condition": {
+            "op": "is",
+            "vars": [
+              {
+                "type": "field",
+                "value": "29c950ea-e45e-4838-a07b-3b640095c940"
+              },
+              {
+                "type": "choice",
+                "value": "3cce3d48-cc5d-4c68-83c3-eec5456a16e4"
+              }
+            ]
+          }
+        },
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "ae1d9d32-1296-4b52-bfb0-2e153756d551"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "field",
+      "ref": "343e8755-c903-42ef-beb5-ad88b5946351",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "87285ecc-3ef2-4793-8430-6eeebb55cb54"
+            }
+          },
+          "condition": {
+            "op": "is",
+            "vars": [
+              {
+                "type": "field",
+                "value": "343e8755-c903-42ef-beb5-ad88b5946351"
+              },
+              {
+                "type": "choice",
+                "value": "424d24a2-7ef6-4c94-8d48-8c3fe3d7d932"
+              }
+            ]
+          }
+        },
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "1df0d0e0-12a0-4bac-b041-3f11f4329c63"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "field",
+      "ref": "90c5d894-46d7-4840-a8d2-01dda7ba430d",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "97a21dee-ab26-45a4-929e-ef79ef815e09"
+            }
+          },
+          "condition": {
+            "op": "is",
+            "vars": [
+              {
+                "type": "field",
+                "value": "90c5d894-46d7-4840-a8d2-01dda7ba430d"
+              },
+              {
+                "type": "choice",
+                "value": "5207f688-93a1-46a6-a286-0e55362aed0f"
+              }
+            ]
+          }
+        },
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "05c42c23-e501-4190-a66c-1e043a6865bd"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "field",
+      "ref": "4d009d19-4e29-49cb-afbd-26e1867fb631",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "8ee92688-0aff-479d-ad00-ec1530dce17a"
+            }
+          },
+          "condition": {
+            "op": "is",
+            "vars": [
+              {
+                "type": "field",
+                "value": "4d009d19-4e29-49cb-afbd-26e1867fb631"
+              },
+              {
+                "type": "choice",
+                "value": "caf313ce-3fea-4f8d-a44e-19468bf5c083"
+              }
+            ]
+          }
+        },
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "257b5962-e30b-4d1f-b752-e4abca0a570d"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "field",
+      "ref": "883939b3-5c06-4f34-87a5-c2657a609d4b",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "84a90275-a7ce-49c2-b2c5-c66247ffcf98"
+            }
+          },
+          "condition": {
+            "op": "is",
+            "vars": [
+              {
+                "type": "field",
+                "value": "883939b3-5c06-4f34-87a5-c2657a609d4b"
+              },
+              {
+                "type": "choice",
+                "value": "8632f660-7832-46e8-8d05-e2c6cf5fef31"
+              }
+            ]
+          }
+        },
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "3f7cdb5c-ebb2-4ea8-9e05-c36400f5380a"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "field",
+      "ref": "8e9e8702-7ab4-431f-b0f5-d0d2cd3261fb",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "599628bc-fdb6-49ae-8dda-5063fa34f565"
+            }
+          },
+          "condition": {
+            "op": "is",
+            "vars": [
+              {
+                "type": "field",
+                "value": "8e9e8702-7ab4-431f-b0f5-d0d2cd3261fb"
+              },
+              {
+                "type": "choice",
+                "value": "0cd126c7-72aa-4b63-8b44-3202fc07057f"
+              }
+            ]
+          }
+        },
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "5c96ea8f-3f79-4784-af6f-a2f63cc4dc5d"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "field",
+      "ref": "0393e7ba-45e8-4325-b0d2-291411e8f319",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "bdf9791e-74f0-4d94-b268-57215c416133"
+            }
+          },
+          "condition": {
+            "op": "is",
+            "vars": [
+              {
+                "type": "field",
+                "value": "0393e7ba-45e8-4325-b0d2-291411e8f319"
+              },
+              {
+                "type": "choice",
+                "value": "223edfa0-cf2f-4a80-8d96-35c731f97234"
+              }
+            ]
+          }
+        },
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "481bb5f7-22cc-4ba3-a29f-1803c33c65b5"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "field",
+      "ref": "62ef617a-90c7-4dfe-87e6-98f700cc315f",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "8bb07475-f826-4617-8d0b-878293ce96d5"
+            }
+          },
+          "condition": {
+            "op": "is",
+            "vars": [
+              {
+                "type": "field",
+                "value": "62ef617a-90c7-4dfe-87e6-98f700cc315f"
+              },
+              {
+                "type": "choice",
+                "value": "11b40126-d4b5-4048-af60-bcb94eaffa8a"
+              }
+            ]
+          }
+        },
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "c02bf04c-c772-43f9-9743-e088ea96fd39"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "field",
+      "ref": "9b9752ce-701d-4861-902f-514b0568b463",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "ade5c304-a9cb-44a0-8e99-3be05f7c6ca4"
+            }
+          },
+          "condition": {
+            "op": "is",
+            "vars": [
+              {
+                "type": "field",
+                "value": "9b9752ce-701d-4861-902f-514b0568b463"
+              },
+              {
+                "type": "choice",
+                "value": "40857c0e-7021-49bb-bf8d-50a0fbd69388"
+              }
+            ]
+          }
+        },
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "48f171fb-1987-4fec-9587-cfd53aaf5215"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "field",
+      "ref": "203fddfa-b4bd-4520-b100-7e87f725be6d",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "6c26f08e-cbbd-4f94-83bb-2cac1106e998"
+            }
+          },
+          "condition": {
+            "op": "is",
+            "vars": [
+              {
+                "type": "field",
+                "value": "203fddfa-b4bd-4520-b100-7e87f725be6d"
+              },
+              {
+                "type": "choice",
+                "value": "e78154b3-5589-40c6-8de4-2e9472198f15"
+              }
+            ]
+          }
+        },
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "64c3f569-5517-41be-ab9f-d5f1b2255e2c"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "field",
+      "ref": "4d2a4bca-54db-4f93-ad23-47ecd998acf4",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "0fb424e0-7d13-4d80-83c3-3403a4816eba"
+            }
+          },
+          "condition": {
+            "op": "is",
+            "vars": [
+              {
+                "type": "field",
+                "value": "4d2a4bca-54db-4f93-ad23-47ecd998acf4"
+              },
+              {
+                "type": "choice",
+                "value": "3c1ee90f-e534-4e61-a554-9d4492e8fbc2"
+              }
+            ]
+          }
+        },
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "391758e5-f1d3-4d06-b217-a009e7cf0f7f"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "field",
+      "ref": "f55dd9ee-6bcd-4438-b61a-9766e38da976",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "c09778dd-d584-40cc-8517-a627592ca5f1"
+            }
+          },
+          "condition": {
+            "op": "is",
+            "vars": [
+              {
+                "type": "field",
+                "value": "f55dd9ee-6bcd-4438-b61a-9766e38da976"
+              },
+              {
+                "type": "constant",
+                "value": true
+              }
+            ]
+          }
+        },
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "d3f1729c-cf2a-4395-b0bc-60212ab9bf1a"
+            }
+          },
+          "condition": {
+            "op": "is",
+            "vars": [
+              {
+                "type": "field",
+                "value": "f55dd9ee-6bcd-4438-b61a-9766e38da976"
+              },
+              {
+                "type": "constant",
+                "value": false
+              }
+            ]
+          }
+        },
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "c09778dd-d584-40cc-8517-a627592ca5f1"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "field",
+      "ref": "25a9c133-1ad8-4e0e-b173-85415fab36c1",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "1324a6cb-0a8a-4684-86fb-b3732d83ad29"
+            }
+          },
+          "condition": {
+            "op": "is",
+            "vars": [
+              {
+                "type": "field",
+                "value": "25a9c133-1ad8-4e0e-b173-85415fab36c1"
+              },
+              {
+                "type": "constant",
+                "value": true
+              }
+            ]
+          }
+        },
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "62bbe9cc-c797-4b7a-ad1d-d4328f7f8589"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "field",
+      "ref": "508ea9df-177c-4cda-8371-8f7cc1bc60a2",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "6156ba3b-1854-4d59-a536-08116c17a4ec"
+            }
+          },
+          "condition": {
+            "op": "or",
+            "vars": [
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "508ea9df-177c-4cda-8371-8f7cc1bc60a2"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "65fd22c3-32ec-4c92-b194-5aef3a10fe60"
+                  }
+                ]
+              },
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "508ea9df-177c-4cda-8371-8f7cc1bc60a2"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "06c83fb6-1725-4c64-b555-df84bfa8e978"
+                  }
+                ]
+              },
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "508ea9df-177c-4cda-8371-8f7cc1bc60a2"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "7a52c8ec-a27c-40ed-bb5c-adff246798c1"
+                  }
+                ]
+              },
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "508ea9df-177c-4cda-8371-8f7cc1bc60a2"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "9eca5aaa-95a9-431f-870e-aafb6dfa9a19"
+                  }
+                ]
+              },
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "508ea9df-177c-4cda-8371-8f7cc1bc60a2"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "b690abd1-78a6-4346-a353-4236e4fb5965"
+                  }
+                ]
+              },
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "508ea9df-177c-4cda-8371-8f7cc1bc60a2"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "1a3456c2-8394-4e19-9122-cd3b6f445c54"
+                  }
+                ]
+              },
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "508ea9df-177c-4cda-8371-8f7cc1bc60a2"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "bb1754b4-8909-4319-ae7f-98a568ebf9ae"
+                  }
+                ]
+              },
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "508ea9df-177c-4cda-8371-8f7cc1bc60a2"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "bc169999-4c23-4bcf-9209-abee3c377b24"
+                  }
+                ]
+              },
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "508ea9df-177c-4cda-8371-8f7cc1bc60a2"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "09f795d1-c8e2-43f2-9e9d-5d7c0430c112"
+                  }
+                ]
+              },
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "508ea9df-177c-4cda-8371-8f7cc1bc60a2"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "6e8a3c11-2a2c-4e6b-b2d3-6ae72df93537"
+                  }
+                ]
+              },
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "508ea9df-177c-4cda-8371-8f7cc1bc60a2"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "606e3e08-c234-4828-bd0f-ba69bba908f0"
+                  }
+                ]
+              },
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "508ea9df-177c-4cda-8371-8f7cc1bc60a2"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "68a23247-0658-4e9b-ba07-dc6c65ec7583"
+                  }
+                ]
+              },
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "508ea9df-177c-4cda-8371-8f7cc1bc60a2"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "da76d9a6-d5d6-4305-b208-78910f2e817a"
+                  }
+                ]
+              },
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "508ea9df-177c-4cda-8371-8f7cc1bc60a2"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "2022bac5-499e-421c-beab-cefc336c2bbc"
+                  }
+                ]
+              },
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "508ea9df-177c-4cda-8371-8f7cc1bc60a2"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "dec3bbdc-afdf-4c46-ae20-a248d023abb2"
+                  }
+                ]
+              },
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "508ea9df-177c-4cda-8371-8f7cc1bc60a2"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "86ea58cc-74c6-4b15-ac6d-9196469d758f"
+                  }
+                ]
+              },
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "508ea9df-177c-4cda-8371-8f7cc1bc60a2"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "8f3bfe75-594c-44e0-845b-656a1a7568c6"
+                  }
+                ]
+              },
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "508ea9df-177c-4cda-8371-8f7cc1bc60a2"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "aafe8b8f-5f75-4e6a-a369-5c8e49d16029"
+                  }
+                ]
+              },
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "508ea9df-177c-4cda-8371-8f7cc1bc60a2"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "9debe884-3a3f-42b1-84fa-8f6a088e2b44"
+                  }
+                ]
+              },
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "508ea9df-177c-4cda-8371-8f7cc1bc60a2"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "faddfe28-ec7d-4509-92f0-ba61aa83a546"
+                  }
+                ]
+              },
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "508ea9df-177c-4cda-8371-8f7cc1bc60a2"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "fd3f8a56-6e0e-4786-8604-b1ff12a8e0a6"
+                  }
+                ]
+              },
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "508ea9df-177c-4cda-8371-8f7cc1bc60a2"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "1d58d3c3-27e6-4b6c-8c96-6e3bafcb512f"
+                  }
+                ]
+              },
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "508ea9df-177c-4cda-8371-8f7cc1bc60a2"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "a2877de6-c50b-499a-98a0-a821c4ae047f"
+                  }
+                ]
+              },
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "508ea9df-177c-4cda-8371-8f7cc1bc60a2"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "2c079aaf-cece-4084-8b8c-8840b1551779"
+                  }
+                ]
+              },
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "508ea9df-177c-4cda-8371-8f7cc1bc60a2"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "22865522-43a0-4637-acb4-a884f81d18a5"
+                  }
+                ]
+              },
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "508ea9df-177c-4cda-8371-8f7cc1bc60a2"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "9790bfbb-0c81-436a-ac96-38042b6cee2c"
+                  }
+                ]
+              },
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "508ea9df-177c-4cda-8371-8f7cc1bc60a2"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "61e2f465-c7c1-4aae-8efb-f764c7276ef6"
+                  }
+                ]
+              },
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "508ea9df-177c-4cda-8371-8f7cc1bc60a2"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "2fcf9300-4aa5-473e-b04c-c055ea85c44c"
+                  }
+                ]
+              },
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "508ea9df-177c-4cda-8371-8f7cc1bc60a2"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "63a1cb8f-ad44-4204-a3ff-46e75060b5d5"
+                  }
+                ]
+              },
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "508ea9df-177c-4cda-8371-8f7cc1bc60a2"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "5d164b1f-9ca4-45a0-aee9-47d116501f6d"
+                  }
+                ]
+              },
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "508ea9df-177c-4cda-8371-8f7cc1bc60a2"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "daf15a6a-3541-40d6-b016-892356786f27"
+                  }
+                ]
+              },
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "508ea9df-177c-4cda-8371-8f7cc1bc60a2"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "0ae32179-85ce-422d-a96a-5f24c9c98721"
+                  }
+                ]
+              },
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "508ea9df-177c-4cda-8371-8f7cc1bc60a2"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "ad743db6-fe4c-4e8e-8368-f802f51458bd"
+                  }
+                ]
+              },
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "508ea9df-177c-4cda-8371-8f7cc1bc60a2"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "92d7c4fe-8a93-4d89-be4f-0efda6b47053"
+                  }
+                ]
+              },
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "508ea9df-177c-4cda-8371-8f7cc1bc60a2"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "928c6f57-c402-46c5-8c2d-20e48d6331d2"
+                  }
+                ]
+              },
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "508ea9df-177c-4cda-8371-8f7cc1bc60a2"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "1d6b4d0f-418a-49e9-aebc-37fbf76f4a7d"
+                  }
+                ]
+              },
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "508ea9df-177c-4cda-8371-8f7cc1bc60a2"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "7513a99e-1a90-468a-aa1a-ccd07d356f4c"
+                  }
+                ]
+              },
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "508ea9df-177c-4cda-8371-8f7cc1bc60a2"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "0b63f26f-2f39-4dbd-8266-36cf91928f2a"
+                  }
+                ]
+              },
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "508ea9df-177c-4cda-8371-8f7cc1bc60a2"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "fd4d4b16-9651-4138-9678-9fe6e2646a1c"
+                  }
+                ]
+              },
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "508ea9df-177c-4cda-8371-8f7cc1bc60a2"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "370f1bf7-c3ac-438b-9e8d-27d01ef11d5e"
+                  }
+                ]
+              },
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "508ea9df-177c-4cda-8371-8f7cc1bc60a2"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "d186f524-49f5-4d30-b32e-f936e0aeea6d"
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "8cd03d7e-412f-4be4-9e80-281f66675fca"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "field",
+      "ref": "6156ba3b-1854-4d59-a536-08116c17a4ec",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "744aaf59-5f8e-47ec-93ee-4053e705e808"
+            }
+          },
+          "condition": {
+            "op": "or",
+            "vars": [
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "6156ba3b-1854-4d59-a536-08116c17a4ec"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "a30bbaa5-8fdc-4269-b486-7d4ef7bb942e"
+                  }
+                ]
+              },
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "6156ba3b-1854-4d59-a536-08116c17a4ec"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "9d3118e5-a080-4608-8e45-1c89512a6635"
+                  }
+                ]
+              },
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "6156ba3b-1854-4d59-a536-08116c17a4ec"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "14fc196c-6c91-4d6a-b7b1-bad62aed4cc9"
+                  }
+                ]
+              },
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "6156ba3b-1854-4d59-a536-08116c17a4ec"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "3783c9dd-76a2-4a21-874a-95718c09d551"
+                  }
+                ]
+              },
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "6156ba3b-1854-4d59-a536-08116c17a4ec"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "69730c1e-a1b0-4ffd-adcf-60160424dbf1"
+                  }
+                ]
+              },
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "6156ba3b-1854-4d59-a536-08116c17a4ec"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "b5321517-ecd2-41ed-866a-2aeb0d60eeef"
+                  }
+                ]
+              },
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "6156ba3b-1854-4d59-a536-08116c17a4ec"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "d1169fb2-283f-4827-9f08-4bac88c4aebe"
+                  }
+                ]
+              },
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "6156ba3b-1854-4d59-a536-08116c17a4ec"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "3ca2cb7a-2427-41bc-b556-1ff7bad96b15"
+                  }
+                ]
+              },
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "6156ba3b-1854-4d59-a536-08116c17a4ec"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "55f72194-1564-4187-81c0-66b3ca963528"
+                  }
+                ]
+              },
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "6156ba3b-1854-4d59-a536-08116c17a4ec"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "82c25c63-92d1-4e37-8913-99caf05ad886"
+                  }
+                ]
+              },
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "6156ba3b-1854-4d59-a536-08116c17a4ec"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "670556fa-f584-4317-ac69-6221bbd47d94"
+                  }
+                ]
+              },
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "6156ba3b-1854-4d59-a536-08116c17a4ec"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "6d5ca16c-afee-4361-9cdf-afae0209dedb"
+                  }
+                ]
+              },
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "6156ba3b-1854-4d59-a536-08116c17a4ec"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "a1db3794-df64-405d-9a2d-5f8a95dc8f15"
+                  }
+                ]
+              },
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "6156ba3b-1854-4d59-a536-08116c17a4ec"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "508f12b8-1b8e-45dc-8362-cae0ee02c4ca"
+                  }
+                ]
+              },
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "6156ba3b-1854-4d59-a536-08116c17a4ec"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "29d238a0-e2ef-4590-b1fe-2d99fbca1c6b"
+                  }
+                ]
+              },
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "6156ba3b-1854-4d59-a536-08116c17a4ec"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "3c8a8877-5ce5-43f3-ac7e-60031f9295e4"
+                  }
+                ]
+              },
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "6156ba3b-1854-4d59-a536-08116c17a4ec"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "041b2956-b4ef-496c-989a-40ad6b79d059"
+                  }
+                ]
+              },
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "6156ba3b-1854-4d59-a536-08116c17a4ec"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "6bd30bad-e1bb-4049-b12f-857a91562bee"
+                  }
+                ]
+              },
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "6156ba3b-1854-4d59-a536-08116c17a4ec"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "ff18fe0c-1f73-442a-b87c-f9b31e813be5"
+                  }
+                ]
+              },
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "6156ba3b-1854-4d59-a536-08116c17a4ec"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "9dbc9cc1-899b-45e9-8ddf-7739ebfafbc7"
+                  }
+                ]
+              },
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "6156ba3b-1854-4d59-a536-08116c17a4ec"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "eacbedc7-0f5d-4cb9-b890-14e091a3febc"
+                  }
+                ]
+              },
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "6156ba3b-1854-4d59-a536-08116c17a4ec"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "70a8d98b-7d12-4fff-916f-95e98ff40cac"
+                  }
+                ]
+              },
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "6156ba3b-1854-4d59-a536-08116c17a4ec"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "0ecfc688-ac4a-46fb-aa12-7760948d32b3"
+                  }
+                ]
+              },
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "6156ba3b-1854-4d59-a536-08116c17a4ec"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "955c749e-9929-4b19-8dab-06597fbf4ffc"
+                  }
+                ]
+              },
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "6156ba3b-1854-4d59-a536-08116c17a4ec"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "2b46c5a3-497b-4887-8793-936e5249c20e"
+                  }
+                ]
+              },
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "6156ba3b-1854-4d59-a536-08116c17a4ec"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "ed774b5e-1c4d-4573-81b8-4ea126b7b201"
+                  }
+                ]
+              },
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "6156ba3b-1854-4d59-a536-08116c17a4ec"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "bbee5625-11fe-4762-b658-90199a071156"
+                  }
+                ]
+              },
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "6156ba3b-1854-4d59-a536-08116c17a4ec"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "4bbd1095-a964-495d-a6b3-f2e9df189fe6"
+                  }
+                ]
+              },
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "6156ba3b-1854-4d59-a536-08116c17a4ec"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "a69009f1-dc68-4a6e-8f28-6239ca8c0e12"
+                  }
+                ]
+              },
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "6156ba3b-1854-4d59-a536-08116c17a4ec"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "b5b13699-2834-4188-9f04-510f5df7d152"
+                  }
+                ]
+              },
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "6156ba3b-1854-4d59-a536-08116c17a4ec"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "38d139d0-6a2f-4c3c-a6f9-82660d696bcf"
+                  }
+                ]
+              },
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "6156ba3b-1854-4d59-a536-08116c17a4ec"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "1f8a3031-225a-4c3c-bf31-633cc12ec3ff"
+                  }
+                ]
+              },
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "6156ba3b-1854-4d59-a536-08116c17a4ec"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "0153d1fd-e8bb-4390-a194-66ebef2fd221"
+                  }
+                ]
+              },
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "6156ba3b-1854-4d59-a536-08116c17a4ec"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "1e1cb047-1d51-4afb-a96b-81734a6b324e"
+                  }
+                ]
+              },
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "6156ba3b-1854-4d59-a536-08116c17a4ec"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "700ae07c-da41-476e-896a-60caea1cef38"
+                  }
+                ]
+              },
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "6156ba3b-1854-4d59-a536-08116c17a4ec"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "166ef976-eec9-4d7a-802e-f1d6cb427919"
+                  }
+                ]
+              },
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "6156ba3b-1854-4d59-a536-08116c17a4ec"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "dd672bee-4877-49e5-b269-639ded86718a"
+                  }
+                ]
+              },
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "6156ba3b-1854-4d59-a536-08116c17a4ec"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "500ebd5f-31a3-4209-a7ed-e5f7830ab846"
+                  }
+                ]
+              },
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "6156ba3b-1854-4d59-a536-08116c17a4ec"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "de640daa-7976-4b4a-82f6-d5598a7c2678"
+                  }
+                ]
+              },
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "6156ba3b-1854-4d59-a536-08116c17a4ec"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "4d094d2f-2f8e-4a01-98ba-6ec7795a0af0"
+                  }
+                ]
+              },
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "6156ba3b-1854-4d59-a536-08116c17a4ec"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "b658db94-fb99-4c4e-ad64-7a268bc6e5a6"
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "8cd03d7e-412f-4be4-9e80-281f66675fca"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "field",
+      "ref": "b6d10646-9cc9-4ad6-a29e-f5e76f155388",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "6d5cdef8-c458-4682-ac41-eb227837dc6d"
+            }
+          },
+          "condition": {
+            "op": "is",
+            "vars": [
+              {
+                "type": "field",
+                "value": "b6d10646-9cc9-4ad6-a29e-f5e76f155388"
+              },
+              {
+                "type": "choice",
+                "value": "e53af6e4-c4f5-48da-832b-d359eb8e8f82"
+              }
+            ]
+          }
+        },
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "343e8755-c903-42ef-beb5-ad88b5946351"
+            }
+          },
+          "condition": {
+            "op": "is",
+            "vars": [
+              {
+                "type": "field",
+                "value": "b6d10646-9cc9-4ad6-a29e-f5e76f155388"
+              },
+              {
+                "type": "choice",
+                "value": "7ed34b43-91cc-4a15-aa62-ad2ef9bfd4a9"
+              }
+            ]
+          }
+        },
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "20f60f31-dff2-4cc1-9a17-88e4a4f2df1a"
+            }
+          },
+          "condition": {
+            "op": "is",
+            "vars": [
+              {
+                "type": "field",
+                "value": "b6d10646-9cc9-4ad6-a29e-f5e76f155388"
+              },
+              {
+                "type": "choice",
+                "value": "a8160cb7-3369-4bd9-b676-4f768d7449e6"
+              }
+            ]
+          }
+        },
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "fa492748-9b26-4f30-b342-ab5a7926c21e"
+            }
+          },
+          "condition": {
+            "op": "is",
+            "vars": [
+              {
+                "type": "field",
+                "value": "b6d10646-9cc9-4ad6-a29e-f5e76f155388"
+              },
+              {
+                "type": "choice",
+                "value": "dfadeff2-becd-4bf1-ac09-44a2b67c09b4"
+              }
+            ]
+          }
+        },
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "95994591-a262-4206-a9c1-c8c5f3444280"
+            }
+          },
+          "condition": {
+            "op": "or",
+            "vars": [
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "b6d10646-9cc9-4ad6-a29e-f5e76f155388"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "c4787ace-a19d-4acd-8401-1b1f3c94946c"
+                  }
+                ]
+              },
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "b6d10646-9cc9-4ad6-a29e-f5e76f155388"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "3a34b42a-b86a-44f8-be3d-20f0ca631029"
+                  }
+                ]
+              },
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "b6d10646-9cc9-4ad6-a29e-f5e76f155388"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "4d5bb0d0-267e-496e-b3dc-d03ce1691422"
+                  }
+                ]
+              },
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "b6d10646-9cc9-4ad6-a29e-f5e76f155388"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "352e97be-4ffd-44f7-9979-20a424d8997d"
+                  }
+                ]
+              },
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "b6d10646-9cc9-4ad6-a29e-f5e76f155388"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "29435820-4262-4463-8586-b77ff5e11023"
+                  }
+                ]
+              },
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "b6d10646-9cc9-4ad6-a29e-f5e76f155388"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "dc366d08-9d69-4ac8-9d44-9ca064d45955"
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "7bb28e91-cbf3-45ea-bc62-9a8cec52399f"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "field",
+      "ref": "1df0d0e0-12a0-4bac-b041-3f11f4329c63",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "8c0e00c0-22d8-4839-983e-36a589819ad7"
+            }
+          },
+          "condition": {
+            "op": "is",
+            "vars": [
+              {
+                "type": "field",
+                "value": "1df0d0e0-12a0-4bac-b041-3f11f4329c63"
+              },
+              {
+                "type": "choice",
+                "value": "83a66cfb-db31-4958-976e-d1e3c16e9bc2"
+              }
+            ]
+          }
+        },
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "96b5324e-2c94-460a-90b1-d4647b6bb8f1"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "field",
+      "ref": "8beed41c-a740-4a05-8a7f-7057266d5822",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "dd69dc04-dea0-4f76-b880-ed16bebee4a4"
+            }
+          },
+          "condition": {
+            "op": "is",
+            "vars": [
+              {
+                "type": "field",
+                "value": "8beed41c-a740-4a05-8a7f-7057266d5822"
+              },
+              {
+                "type": "choice",
+                "value": "d32588fd-681f-4d40-b0bc-0ed1cb4ac1bb"
+              }
+            ]
+          }
+        },
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "f69d08b4-ad76-489a-9623-efb21ae5320d"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "field",
+      "ref": "aea7a268-64d4-4f16-920a-b9afe317e3b6",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "b6d10646-9cc9-4ad6-a29e-f5e76f155388"
+            }
+          },
+          "condition": {
+            "op": "is",
+            "vars": [
+              {
+                "type": "field",
+                "value": "aea7a268-64d4-4f16-920a-b9afe317e3b6"
+              },
+              {
+                "type": "choice",
+                "value": "3faf5f88-5171-4933-af0f-210716bf1a60"
+              }
+            ]
+          }
+        },
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "90c5d894-46d7-4840-a8d2-01dda7ba430d"
+            }
+          },
+          "condition": {
+            "op": "is",
+            "vars": [
+              {
+                "type": "field",
+                "value": "aea7a268-64d4-4f16-920a-b9afe317e3b6"
+              },
+              {
+                "type": "choice",
+                "value": "173074a1-75b3-45d2-a6d6-298bfa2bb825"
+              }
+            ]
+          }
+        },
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "9b9752ce-701d-4861-902f-514b0568b463"
+            }
+          },
+          "condition": {
+            "op": "is",
+            "vars": [
+              {
+                "type": "field",
+                "value": "aea7a268-64d4-4f16-920a-b9afe317e3b6"
+              },
+              {
+                "type": "choice",
+                "value": "4f6732f3-d3b6-4c83-9c3e-a4945a004507"
+              }
+            ]
+          }
+        },
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "d19059fc-5bf5-4033-9a2a-ea1ae86c90cf"
+            }
+          },
+          "condition": {
+            "op": "is",
+            "vars": [
+              {
+                "type": "field",
+                "value": "aea7a268-64d4-4f16-920a-b9afe317e3b6"
+              },
+              {
+                "type": "choice",
+                "value": "014b478f-eed1-4329-8d4f-8b89335a3faf"
+              }
+            ]
+          }
+        },
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "070dd1c6-4e1e-4464-985e-83949c8d0eea"
+            }
+          },
+          "condition": {
+            "op": "is",
+            "vars": [
+              {
+                "type": "field",
+                "value": "aea7a268-64d4-4f16-920a-b9afe317e3b6"
+              },
+              {
+                "type": "choice",
+                "value": "c9291e36-0cf3-454c-b9f6-c96538ef6b5f"
+              }
+            ]
+          }
+        },
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "203fddfa-b4bd-4520-b100-7e87f725be6d"
+            }
+          },
+          "condition": {
+            "op": "is",
+            "vars": [
+              {
+                "type": "field",
+                "value": "aea7a268-64d4-4f16-920a-b9afe317e3b6"
+              },
+              {
+                "type": "choice",
+                "value": "8ff81563-9786-44c5-8f1a-3aa17d7929e5"
+              }
+            ]
+          }
+        },
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "391758e5-f1d3-4d06-b217-a009e7cf0f7f"
+            }
+          },
+          "condition": {
+            "op": "or",
+            "vars": [
+              {
+                "op": "and",
+                "vars": [
+                  {
+                    "op": "is",
+                    "vars": [
+                      {
+                        "type": "field",
+                        "value": "aea7a268-64d4-4f16-920a-b9afe317e3b6"
+                      },
+                      {
+                        "type": "choice",
+                        "value": "9c7f877f-b66b-4559-b572-557b60157a3c"
+                      }
+                    ]
+                  },
+                  {
+                    "op": "is",
+                    "vars": [
+                      {
+                        "type": "field",
+                        "value": "4915db69-55ca-4a00-b57e-893d7ea3e761"
+                      },
+                      {
+                        "type": "choice",
+                        "value": "2f202927-97b2-4d9c-aaef-1296fb68c5ba"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "4915db69-55ca-4a00-b57e-893d7ea3e761"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "e6a75660-04b1-445a-bdd4-13b95e5a2114"
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "25a9c133-1ad8-4e0e-b173-85415fab36c1"
+            }
+          },
+          "condition": {
+            "op": "and",
+            "vars": [
+              {
+                "op": "is",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "aea7a268-64d4-4f16-920a-b9afe317e3b6"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "9c7f877f-b66b-4559-b572-557b60157a3c"
+                  }
+                ]
+              },
+              {
+                "op": "is_not",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "4915db69-55ca-4a00-b57e-893d7ea3e761"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "2f202927-97b2-4d9c-aaef-1296fb68c5ba"
+                  }
+                ]
+              },
+              {
+                "op": "is_not",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "4915db69-55ca-4a00-b57e-893d7ea3e761"
+                  },
+                  {
+                    "type": "choice",
+                    "value": "e6a75660-04b1-445a-bdd4-13b95e5a2114"
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "391758e5-f1d3-4d06-b217-a009e7cf0f7f"
+            }
+          },
+          "condition": {
+            "op": "is",
+            "vars": [
+              {
+                "type": "field",
+                "value": "aea7a268-64d4-4f16-920a-b9afe317e3b6"
+              },
+              {
+                "type": "choice",
+                "value": "415b4154-14c4-425f-8d0f-a1a1a1ee7cc3"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "field",
+      "ref": "58d9fbe4-7e9f-4da9-aafc-f3b36e747533",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "a0c4a70d-17bf-40e8-a0a2-9e4be165177f"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "field",
+      "ref": "76aea2fa-cba3-400a-b0d8-485416241861",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "d7f05a87-e981-403b-8113-ddba96ad4160"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "field",
+      "ref": "d507cc27-5716-4b21-ae06-abaa5a55ee19",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "aea7a268-64d4-4f16-920a-b9afe317e3b6"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "field",
+      "ref": "a6521f1c-0bcc-4163-9373-c286a34dd2ca",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "cb42a04e-04e6-40c3-b96a-33cc66c2f02f"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "field",
+      "ref": "12b4401d-435e-4e89-82ff-8a26d312bcc6",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "391758e5-f1d3-4d06-b217-a009e7cf0f7f"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "field",
+      "ref": "64c3f569-5517-41be-ab9f-d5f1b2255e2c",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "391758e5-f1d3-4d06-b217-a009e7cf0f7f"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "field",
+      "ref": "5dea4979-aeb1-4aca-ac27-d4022f5cf4fa",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "3e8760df-4a6e-47f2-8b03-0ef2e72ac35f"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "field",
+      "ref": "fa492748-9b26-4f30-b342-ab5a7926c21e",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "5bd9d76e-7577-4138-b81a-df4c4abb12d8"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "field",
+      "ref": "7bb28e91-cbf3-45ea-bc62-9a8cec52399f",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "c4c6e7dc-06a2-4250-9878-3f2f30095eec"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "field",
+      "ref": "fa2f6cf9-13ff-4c73-9f29-40a0b986f3b8",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "ae1d9d32-1296-4b52-bfb0-2e153756d551"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "field",
+      "ref": "f4040a6a-7c46-4f22-a659-61bf9c713cdc",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "c09778dd-d584-40cc-8517-a627592ca5f1"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "field",
+      "ref": "d3f1729c-cf2a-4395-b0bc-60212ab9bf1a",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "c09778dd-d584-40cc-8517-a627592ca5f1"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "field",
+      "ref": "744aaf59-5f8e-47ec-93ee-4053e705e808",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "8cd03d7e-412f-4be4-9e80-281f66675fca"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "field",
+      "ref": "1324a6cb-0a8a-4684-86fb-b3732d83ad29",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "62bbe9cc-c797-4b7a-ad1d-d4328f7f8589"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "field",
+      "ref": "accaed1d-ad66-45bc-94d2-b6826f5da3f7",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "ae1d9d32-1296-4b52-bfb0-2e153756d551"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "field",
+      "ref": "c4cbe655-3bdc-4c1b-8b4c-b37b67141b89",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "ae1d9d32-1296-4b52-bfb0-2e153756d551"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "field",
+      "ref": "3bdc4355-214a-4c3e-9220-e49cb136845c",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "ae1d9d32-1296-4b52-bfb0-2e153756d551"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "field",
+      "ref": "96b5324e-2c94-460a-90b1-d4647b6bb8f1",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "ae1d9d32-1296-4b52-bfb0-2e153756d551"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "field",
+      "ref": "396ddc90-a1f2-4268-b7f0-f4491331b256",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "391758e5-f1d3-4d06-b217-a009e7cf0f7f"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "field",
+      "ref": "acedb884-d985-4b8d-a70d-8b2948409a79",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "4d009d19-4e29-49cb-afbd-26e1867fb631"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "field",
+      "ref": "8ee92688-0aff-479d-ad00-ec1530dce17a",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "257b5962-e30b-4d1f-b752-e4abca0a570d"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "field",
+      "ref": "84a90275-a7ce-49c2-b2c5-c66247ffcf98",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "3f7cdb5c-ebb2-4ea8-9e05-c36400f5380a"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "field",
+      "ref": "599628bc-fdb6-49ae-8dda-5063fa34f565",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "5c96ea8f-3f79-4784-af6f-a2f63cc4dc5d"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "field",
+      "ref": "87ab4476-c084-41b5-8add-8d8e26e5d4f8",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "0393e7ba-45e8-4325-b0d2-291411e8f319"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "field",
+      "ref": "bdf9791e-74f0-4d94-b268-57215c416133",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "481bb5f7-22cc-4ba3-a29f-1803c33c65b5"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "field",
+      "ref": "b045eb9e-65f4-4685-a416-ea0d64ead194",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "daab8076-557d-4572-a489-14d08038ff4b"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "field",
+      "ref": "c5a79da8-d8f4-4250-9a4a-169d1af7e805",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "a099c975-05d2-4368-8ead-8b0ca02cdbf9"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "field",
+      "ref": "8bb07475-f826-4617-8d0b-878293ce96d5",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "c02bf04c-c772-43f9-9743-e088ea96fd39"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "field",
+      "ref": "4639aca9-0fa6-413d-8fa6-ef5854485d6e",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "3e8760df-4a6e-47f2-8b03-0ef2e72ac35f"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "field",
+      "ref": "f69d08b4-ad76-489a-9623-efb21ae5320d",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "3e8760df-4a6e-47f2-8b03-0ef2e72ac35f"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "field",
+      "ref": "dd69dc04-dea0-4f76-b880-ed16bebee4a4",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "3e8760df-4a6e-47f2-8b03-0ef2e72ac35f"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "field",
+      "ref": "e7e62496-6253-4887-9164-01cbc41aae54",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "391758e5-f1d3-4d06-b217-a009e7cf0f7f"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "field",
+      "ref": "0fb424e0-7d13-4d80-83c3-3403a4816eba",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "391758e5-f1d3-4d06-b217-a009e7cf0f7f"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "field",
+      "ref": "05c42c23-e501-4190-a66c-1e043a6865bd",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "78402997-6809-4f34-90bd-7eac13159171"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "field",
+      "ref": "391758e5-f1d3-4d06-b217-a009e7cf0f7f",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "thankyou",
+              "value": "be7e8121-9449-4993-863a-7fa9326656b9"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    }
+  ],
+  "_links": {
+    "display": "https://tohanuk.typeform.com/to/qLnHVjxj"
+  }
+}

--- a/typeform/src/commonMain/kotlin/com/typeform/models/Responses.kt
+++ b/typeform/src/commonMain/kotlin/com/typeform/models/Responses.kt
@@ -139,3 +139,15 @@ fun Responses.invalidResponseValuesGiven(fields: List<Field>): List<String> {
         ref
     }
 }
+
+internal fun Responses.responseRequiredFor(field: Field): Boolean {
+    if (field.validations == null) {
+        return false
+    }
+
+    if (!field.validations.required) {
+        return false
+    }
+
+    return this[field.ref] == null
+}

--- a/typeform/src/commonMain/kotlin/com/typeform/models/TypeformException.kt
+++ b/typeform/src/commonMain/kotlin/com/typeform/models/TypeformException.kt
@@ -6,6 +6,7 @@ sealed class TypeformException : Exception {
     private constructor(message: String, cause: Throwable) : super(message, cause)
     private constructor(cause: Throwable) : super(cause)
 
-    object ResponseValueRequired : TypeformException("Field validations indicate a required response which is missing.")
+    data object ResponseValueRequired : TypeformException("Field validations indicate a required response which is missing.")
+    data object FirstPosition : TypeformException("The first position could not be determined.")
     data class NextPosition(val from: Position) : TypeformException("The next position could not be determined.")
 }


### PR DESCRIPTION
# Description

Updates the library with support for pre-loaded responses. While determining the _first_ & _next_ `Position` (I.e. question to answer), the current responses will be checked. If an answer already exists, then the question will be skipped. The final `Conclusion` from a `Form` will always include _all_ responses.

## New/Updated Features

Some changes to how UI state management were also made. The entire _current_ response state is passed into the next view, meaning that each view will always have a consistent representation of the state at that time, leading to fewer unintended changes. Also added is a `ResponseState` representation the collects state changes from each question view; limiting the number of callbacks needing to be managed.

Internal Reference: PATM-896