### PR TITLE
First Position Fallbacks

### DIFF
--- a/typeform/src/androidMain/kotlin/com/typeform/ui/structure/FormView.kt
+++ b/typeform/src/androidMain/kotlin/com/typeform/ui/structure/FormView.kt
@@ -60,8 +60,8 @@ fun FormView(
     var showBackNavigation by remember { mutableStateOf(false) }
     var showConfirmCancel by remember { mutableStateOf(false) }
 
-    val startDestination = remember {
-        val firstPosition: Position? = try {
+    val startPosition: Position? = remember {
+        try {
             form.firstPosition(
                 skipWelcomeScreen = settings.presentation.skipWelcomeScreen,
                 responses = responses
@@ -69,13 +69,15 @@ fun FormView(
         } catch (_: Exception) {
             null
         }
+    }
 
-        return@remember when (firstPosition) {
+    val startDestination = remember {
+        when (startPosition) {
             is Position.ScreenPosition -> {
-                Pair(TypeformRoute.screen, firstPosition.screen.id)
+                Pair(TypeformRoute.screen, startPosition.screen.id)
             }
             is Position.FieldPosition -> {
-                Pair(TypeformRoute.field, firstPosition.field.id)
+                Pair(TypeformRoute.field, startPosition.field.id)
             }
             else -> {
                 Pair(TypeformRoute.rejected, "")
@@ -172,7 +174,7 @@ fun FormView(
                 ),
             ) {
                 showBackNavigation = false
-                val id = it.arguments?.getString("id") ?: form.firstScreen?.id
+                val id = (it.arguments?.getString("id") ?: startPosition?.associatedScreen()?.id) ?: form.firstScreen?.id
                 if (id == null) {
                     RejectedView(
                         scaffoldPadding = scaffoldPadding,
@@ -217,7 +219,7 @@ fun FormView(
                     },
                 ),
             ) {
-                val fieldId = it.arguments?.getString("id") ?: form.fields.firstOrNull()?.id
+                val fieldId = (it.arguments?.getString("id") ?: startPosition?.associatedField()?.id) ?: form.fields.firstOrNull()?.id
                 if (fieldId == null) {
                     showBackNavigation = false
                     RejectedView(

--- a/typeform/src/commonMain/kotlin/com/typeform/models/Position.kt
+++ b/typeform/src/commonMain/kotlin/com/typeform/models/Position.kt
@@ -9,6 +9,17 @@ sealed class Position {
     data class ScreenPosition(val screen: Screen) : Position()
     data class FieldPosition(val field: Field, val group: Group?) : Position()
 
+    fun associatedScreen(): Screen? {
+        return when(this) {
+            is ScreenPosition -> {
+                this.screen
+            }
+            else -> {
+                null
+            }
+        }
+    }
+
     fun associatedField(): Field? {
         return when(this) {
             is FieldPosition -> {


### PR DESCRIPTION
# Description

A quick bug-fix from #2. While implementing a pre-loaded response form that skipped the first question, the first question was still appears. This was a result of falling back to the first question in a form when a routing argument was not present. Now the _start position_ screen/field reference is preferred in these situations.


