### PR TITLE
Opinion Scale Styling

### DIFF
--- a/typeform/src/androidMain/kotlin/com/typeform/ui/components/IntermittentChoiceButton.kt
+++ b/typeform/src/androidMain/kotlin/com/typeform/ui/components/IntermittentChoiceButton.kt
@@ -24,8 +24,30 @@ internal fun IntermittentChoiceButton(
     selected: Boolean = false,
     onClick: () -> Unit,
 ) {
-    val background = if (selected) settings.interaction.selectedBackgroundColor else settings.interaction.unselectedBackgroundColor
-    val border = if (selected) settings.interaction.selectedStrokeColor else settings.interaction.unselectedStrokeColor
+    val backgroundColor = if (allowMultiple == null) {
+        if (selected) settings.rating.selectedBackgroundColor else settings.rating.unselectedBackgroundColor
+    } else {
+        if (selected) settings.interaction.selectedBackgroundColor else settings.interaction.unselectedBackgroundColor
+    }
+
+    val strokeColor = if (allowMultiple == null) {
+        if (selected) settings.rating.selectedStrokeColor else settings.rating.unselectedStrokeColor
+    } else {
+        if (selected) settings.interaction.selectedStrokeColor else settings.interaction.unselectedStrokeColor
+    }
+
+    val strokeWidth = if (allowMultiple == null) {
+        if (selected) settings.rating.selectedStrokeWidth else settings.rating.unselectedStrokeWidth
+    } else {
+        if (selected) settings.interaction.selectedStrokeWidth else settings.interaction.unselectedStrokeWidth
+    }
+
+    val foregroundColor = if (allowMultiple == null) {
+        if (selected) settings.rating.selectedForegroundColor else settings.rating.unselectedForegroundColor
+    } else {
+        MaterialTheme.colors.onBackground
+    }
+    
     val textModifier = if (allowMultiple == null) Modifier else Modifier.fillMaxWidth()
 
     Button(
@@ -33,11 +55,11 @@ internal fun IntermittentChoiceButton(
         modifier = modifier,
         elevation = null,
         border = BorderStroke(
-            width = settings.interaction.unselectedStrokeWidth,
-            color = border,
+            width = strokeWidth,
+            color = strokeColor,
         ),
         colors = ButtonDefaults.buttonColors(
-            backgroundColor = background,
+            backgroundColor = backgroundColor,
         ),
         contentPadding = PaddingValues(),
     ) {
@@ -58,6 +80,7 @@ internal fun IntermittentChoiceButton(
                 text = text,
                 modifier = textModifier,
                 textStyle = MaterialTheme.typography.body1,
+                color = foregroundColor,
             )
         }
     }

--- a/typeform/src/androidMain/kotlin/com/typeform/ui/fields/OpinionScaleView.kt
+++ b/typeform/src/androidMain/kotlin/com/typeform/ui/fields/OpinionScaleView.kt
@@ -38,7 +38,7 @@ internal fun OpinionScaleView(
     val end = if (properties.start_at_one) properties.steps else properties.steps - 1
     val range = IntRange(start, end)
     val leadingLabel = String.format("%d: %s", start, properties.labels.left)
-    val trailingLabel = String.format("%d: %s", start, properties.labels.right)
+    val trailingLabel = String.format("%d: %s", end, properties.labels.right)
 
     fun updateState() {
         var state = responseState
@@ -132,9 +132,9 @@ private fun OpinionScaleViewPreviewFillMaxWidth() {
             )
         ),
         properties = OpinionScale(
-            steps = 11,
+            steps = 10,
             labels = OpinionScale.Labels("leading", "trailing"),
-            start_at_one = false,
+            start_at_one = true,
         ),
         responseState = ResponseState(),
         validations = null,

--- a/typeform/src/androidMain/kotlin/com/typeform/ui/fields/OpinionScaleView.kt
+++ b/typeform/src/androidMain/kotlin/com/typeform/ui/fields/OpinionScaleView.kt
@@ -34,10 +34,11 @@ internal fun OpinionScaleView(
 ) {
     var selected: Int? by remember { mutableStateOf(responseState.response?.asInt()) }
 
-    val range = IntRange(
-        if (properties.start_at_one) 1 else 0,
-        if (properties.start_at_one) properties.steps else properties.steps - 1
-    )
+    val start = if (properties.start_at_one) 1 else 0
+    val end = if (properties.start_at_one) properties.steps else properties.steps - 1
+    val range = IntRange(start, end)
+    val leadingLabel = String.format("%d: %s", start, properties.labels.left)
+    val trailingLabel = String.format("%d: %s", start, properties.labels.right)
 
     fun updateState() {
         var state = responseState
@@ -72,12 +73,12 @@ internal fun OpinionScaleView(
             horizontalArrangement = Arrangement.SpaceBetween,
         ) {
             StyledTextView(
-                text = properties.labels.left,
+                text = leadingLabel,
                 textStyle = MaterialTheme.typography.caption,
             )
 
             StyledTextView(
-                text = properties.labels.right,
+                text = trailingLabel,
                 textStyle = MaterialTheme.typography.caption,
             )
         }

--- a/typeform/src/androidMain/kotlin/com/typeform/ui/models/Settings.kt
+++ b/typeform/src/androidMain/kotlin/com/typeform/ui/models/Settings.kt
@@ -69,9 +69,11 @@ data class Settings(
         val unselectedBackgroundColor: Color = Color.Blue.copy(alpha = 0.2f),
         val unselectedStrokeColor: Color = Color.Blue.copy(alpha = 0.5f),
         val unselectedStrokeWidth: Dp = 1.dp,
+        val unselectedForegroundColor: Color = Color.White,
         val selectedBackgroundColor: Color = Color.Blue.copy(alpha = 0.5f),
         val selectedStrokeColor: Color = Color.Blue.copy(alpha = 0.8f),
         val selectedStrokeWidth: Dp = 2.dp,
+        val selectedForegroundColor: Color = Color.Blue,
         val padding: PaddingValues = PaddingValues(10.dp),
         val horizontalSpacing: Dp = 10.dp,
         val contentCornerRadius: Dp = 6.dp,
@@ -104,7 +106,13 @@ data class Settings(
     )
 
     data class Rating(
+        val unselectedBackgroundColor: Color = Color.Blue.copy(alpha = 0.3f),
+        val unselectedStrokeColor: Color = Color.Blue.copy(alpha = 0.5f),
+        val unselectedStrokeWidth: Dp = 1.dp,
         val unselectedForegroundColor: Color = Color.Black,
+        val selectedBackgroundColor: Color = Color.Blue.copy(alpha = 0.3f),
+        val selectedStrokeColor: Color = Color.Blue.copy(alpha = 0.9f),
+        val selectedStrokeWidth: Dp = 2.dp,
         val selectedForegroundColor: Color = Color.Blue,
         val fillMaxWidth: Boolean = false,
     )


### PR DESCRIPTION
# Description

The OpinionScale buttons sometimes need a different styling that the radio/checkbox options stemming from no extra indications of selection status. This update adds support for defining additional styling information as well as add the numerical prefixes to the opinion scale labels.

Internal Reference: PATM-934

