### PR TITLE
DatePicker Updates

### DIFF
--- a/typeform/build.gradle.kts
+++ b/typeform/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     kotlin("multiplatform")
     id("com.android.library")
-    id("org.jetbrains.compose") version "1.5.3"
+    id("org.jetbrains.compose") version "1.6.1"
     id("com.adarshr.test-logger") version "3.2.0"
 }
 
@@ -36,8 +36,8 @@ kotlin {
                 api(compose.ui)
                 api(compose.uiTooling)
                 api(compose.preview)
-                implementation("androidx.compose.material3:material3:1.1.2")
-                implementation("androidx.navigation:navigation-compose:2.7.5")
+                implementation("androidx.compose.material3:material3:1.2.0")
+                implementation("androidx.navigation:navigation-compose:2.7.7")
                 implementation("io.coil-kt:coil-compose:2.4.0")
             }
         }

--- a/typeform/src/androidMain/kotlin/com/typeform/ui/fields/DateView.kt
+++ b/typeform/src/androidMain/kotlin/com/typeform/ui/fields/DateView.kt
@@ -12,6 +12,7 @@ import androidx.compose.material3.DatePickerDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.rememberDatePickerState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -67,6 +68,11 @@ internal fun DateView(
         updateState()
     }
 
+    DisposableEffect(pickerState.selectedDateMillis) {
+        select(pickerState.selectedDateMillis)
+        onDispose { }
+    }
+
     Column(
         verticalArrangement = Arrangement.spacedBy(settings.presentation.descriptionContentVerticalSpacing),
     ) {
@@ -76,6 +82,11 @@ internal fun DateView(
                 textStyle = MaterialTheme.typography.caption,
             )
         }
+
+        StyledTextView(
+            text = "$milliseconds",
+            textStyle = MaterialTheme.typography.h1
+        )
 
         Column(
             verticalArrangement = Arrangement.spacedBy(settings.presentation.contentVerticalSpacing),
@@ -112,10 +123,6 @@ internal fun DateView(
             if (!isOptional || !isNotSure) {
                 DatePicker(
                     state = pickerState,
-                    dateValidator = {
-                        select(it)
-                        true
-                    },
                     title = null,
                     headline = null,
                     showModeToggle = false,

--- a/typeform/src/androidMain/kotlin/com/typeform/ui/fields/DateView.kt
+++ b/typeform/src/androidMain/kotlin/com/typeform/ui/fields/DateView.kt
@@ -83,25 +83,20 @@ internal fun DateView(
             )
         }
 
-        StyledTextView(
-            text = "$milliseconds",
-            textStyle = MaterialTheme.typography.h1
-        )
-
         Column(
             verticalArrangement = Arrangement.spacedBy(settings.presentation.contentVerticalSpacing),
         ) {
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                StyledTextView(
-                    text = settings.localization.nullDate,
-                    textStyle = MaterialTheme.typography.caption,
-                )
+            if (isOptional) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    StyledTextView(
+                        text = settings.localization.nullDate,
+                        textStyle = MaterialTheme.typography.caption,
+                    )
 
-                if (isOptional) {
                     Switch(
                         checked = isNotSure,
                         onCheckedChange = {


### PR DESCRIPTION
# Description

Newer versions of Compose removed the `dateValidator` from the `DatePicker`, and that was being used as a work-around to relay the value of the selected date. I've updated compose and moved to using a `DisposableEffect` that processes the selected date when it changes.

Also, I've fixes the display of when a date is marked as non-optional. The 'not sure' text was still visible.

Internal Reference: PATM-953

