### PR TITLE
Optional Capabilities

### DIFF
--- a/typeform/src/commonMain/kotlin/com/typeform/schema/Settings.kt
+++ b/typeform/src/commonMain/kotlin/com/typeform/schema/Settings.kt
@@ -5,7 +5,7 @@ data class Settings(
     val is_trial: Boolean,
     val language: String,
     val is_public: Boolean,
-    val capabilities: Capabilities,
+    val capabilities: Capabilities?,
     val progress_bar: String,
     val hide_navigation: Boolean,
     val show_progress_bar: Boolean,
@@ -21,7 +21,7 @@ data class Settings(
     )
 
     data class Capabilities(
-        val e2e_encryption: EndToEndEncryption,
+        val e2e_encryption: EndToEndEncryption?,
     )
 
     data class EndToEndEncryption(


### PR DESCRIPTION
# Description

Removes the requirement to supply `Capabilities` as part of the `Settings` structure. This value doesn't seem to appear in the latest version of the API documents for retrieving forms.

Internal Reference: PATM-1053