### PR TITLE
kotlinx-serialization

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     //trick: for the same plugin versions in all sub-modules
-    kotlin("multiplatform").version("1.9.10").apply(false)
-    id("com.android.library").version("8.1.2").apply(false)
+    kotlin("multiplatform").version(libs.versions.kotlin).apply(false)
+    alias(libs.plugins.androidLibrary).apply(false)
     id("maven-publish")
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Oct 12 15:56:51 CDT 2023
+#Fri Oct 11 16:26:47 CDT 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -11,6 +11,21 @@ dependencyResolutionManagement {
         google()
         mavenCentral()
     }
+    versionCatalogs {
+        create("libs") {
+            version("android.plugin", "8.7.0")
+            version("compose", "1.6.11")
+            version("gradle.wrapper", "8.9")
+            version("kotlin", "2.0.21")
+
+            plugin("androidLibrary", "com.android.library").versionRef("android.plugin")
+            plugin("compose", "org.jetbrains.compose").versionRef("compose")
+            plugin("composeCompiler", "org.jetbrains.kotlin.plugin.compose").versionRef("kotlin")
+            plugin("kotlinMultiplatform", "org.jetbrains.kotlin.multiplatform").versionRef("kotlin")
+            plugin("kotlinSerialization", "org.jetbrains.kotlin.plugin.serialization").versionRef("kotlin")
+            plugin("testLogger", "com.adarshr.test-logger").version("3.2.0")
+        }
+    }
 }
 
 rootProject.name = "typeform-kotlin"

--- a/typeform/build.gradle.kts
+++ b/typeform/build.gradle.kts
@@ -1,23 +1,23 @@
 plugins {
     kotlin("multiplatform")
-    id("com.android.library")
-    id("org.jetbrains.compose") version "1.6.1"
-    id("com.adarshr.test-logger") version "3.2.0"
+    alias(libs.plugins.androidLibrary)
+    alias(libs.plugins.kotlinSerialization)
+    alias(libs.plugins.compose)
+    alias(libs.plugins.composeCompiler)
+    alias(libs.plugins.testLogger)
 }
 
 kotlin {
     androidTarget {
-        compilations.all {
-            kotlinOptions {
-                jvmTarget = "17"
-            }
-
-            publishLibraryVariants("release")
-        }
     }
+
+    jvmToolchain(17)
 
     sourceSets {
         val commonMain by getting {
+            dependencies {
+                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3")
+            }
         }
 
         val commonTest by getting {
@@ -45,8 +45,6 @@ kotlin {
         val androidUnitTest by getting {
             dependencies {
                 implementation(kotlin("test"))
-                implementation("com.squareup.moshi:moshi-kotlin-codegen:1.15.0")
-                implementation("com.squareup.moshi:moshi-kotlin:1.15.0")
             }
         }
     }

--- a/typeform/src/androidUnitTest/kotlin/com/typeform/SchemaTests.kt
+++ b/typeform/src/androidUnitTest/kotlin/com/typeform/SchemaTests.kt
@@ -1,8 +1,5 @@
 package com.typeform
 
-import com.typeform.adapters.FlatForm
-import com.typeform.adapters.make
-import com.typeform.schema.Form
 import com.typeform.schema.WelcomeScreen
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -10,17 +7,6 @@ import kotlin.test.assertTrue
 import kotlin.test.fail
 
 class SchemaTests : TypeformTestCase() {
-
-    @Test
-    fun testFormDecoding() {
-        val flatFormAdapter = moshi.adapter(FlatForm::class.java)
-        val flatForm = assertUnwrap(flatFormAdapter.fromJson(json))
-
-        assertEquals(Form.make(flatForm), form)
-
-        assertEquals(152, form.logic.count())
-        assertEquals(56, form.fields.count())
-    }
 
     @Test
     fun testFirstScreen() {

--- a/typeform/src/androidUnitTest/kotlin/com/typeform/TypeformTestCase.kt
+++ b/typeform/src/androidUnitTest/kotlin/com/typeform/TypeformTestCase.kt
@@ -1,21 +1,7 @@
 package com.typeform
 
-import com.squareup.moshi.FromJson
-import com.squareup.moshi.Moshi
-import com.squareup.moshi.ToJson
-import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
-import com.typeform.adapters.FlatForm
-import com.typeform.adapters.make
-import com.typeform.schema.ActionDetails
-import com.typeform.schema.ActionType
 import com.typeform.schema.Choice
-import com.typeform.schema.FieldType
 import com.typeform.schema.Form
-import com.typeform.schema.FormType
-import com.typeform.schema.LogicType
-import com.typeform.schema.Op
-import com.typeform.schema.VarType
-import java.net.URL
 
 open class TypeformTestCase {
     companion object {
@@ -67,94 +53,7 @@ open class TypeformTestCase {
         )
     }
 
-    class UrlAdapter {
-        @ToJson
-        fun toJson(type: URL): String = type.toString()
-
-        @FromJson
-        fun fromJson(rawValue: String): URL = URL(rawValue)
-    }
-
-    class TypeformFormAdapter {
-        @ToJson
-        fun toJson(type: Form): FlatForm = FlatForm.make(type)
-
-        @FromJson
-        fun fromJson(rawValue: FlatForm): Form = Form.make(rawValue)
-    }
-
-    class TypeformActionTypeAdapter {
-        @ToJson
-        fun toJson(type: ActionType): String = type.rawValue
-
-        @FromJson
-        fun fromJson(rawValue: String): ActionType = ActionType.fromRawValue(rawValue)
-    }
-
-    class TypeformFieldTypeAdapter {
-        @ToJson
-        fun toJson(type: FieldType): String = type.rawValue
-
-        @FromJson
-        fun fromJson(rawValue: String): FieldType = FieldType.fromRawValue(rawValue)
-    }
-
-    class TypeformFormTypeAdapter {
-        @ToJson
-        fun toJson(type: FormType): String = type.rawValue
-
-        @FromJson
-        fun fromJson(rawValue: String): FormType = FormType.fromRawValue(rawValue)
-    }
-
-    class TypeformLogicTypeAdapter {
-        @ToJson
-        fun toJson(type: LogicType): String = type.rawValue
-
-        @FromJson
-        fun fromJson(rawValue: String): LogicType = LogicType.fromRawValue(rawValue)
-    }
-
-    class TypeformOpAdapter {
-        @ToJson
-        fun toJson(type: Op): String = type.rawValue
-
-        @FromJson
-        fun fromJson(rawValue: String): Op = Op.fromRawValue(rawValue)
-    }
-
-    class TypeformVarTypeAdapter {
-        @ToJson
-        fun toJson(type: VarType): String = type.rawValue
-
-        @FromJson
-        fun fromJson(rawValue: String): VarType = VarType.fromRawValue(rawValue)
-    }
-
-    class TypeformActionDetailsToTypeAdapter {
-        @ToJson
-        fun toJson(type: ActionDetails.ToType): String = type.rawValue
-
-        @FromJson
-        fun fromJson(rawValue: String): ActionDetails.ToType = ActionDetails.ToType.fromRawValue(rawValue)
-    }
-
     val resources: Resources = Resources()
-    val moshi: Moshi
-        get() = Moshi.Builder()
-            .add(UrlAdapter())
-            .add(TypeformFormAdapter())
-            .add(TypeformFormTypeAdapter())
-            .add(TypeformFieldTypeAdapter())
-            .add(TypeformLogicTypeAdapter())
-            .add(TypeformOpAdapter())
-            .add(TypeformVarTypeAdapter())
-            .add(TypeformActionTypeAdapter())
-            .add(TypeformActionDetailsToTypeAdapter())
-            .add(KotlinJsonAdapterFactory())
-            .build()
-
-    val json: String
     val form: Form
 
     open val jsonResource: String
@@ -162,8 +61,7 @@ open class TypeformTestCase {
 
     init {
         val formBytes = resources.contentOfResource(jsonResource)
-        json = String(formBytes)
-        val formAdapter = moshi.adapter(Form::class.java)
-        form = assertUnwrap(formAdapter.fromJson(json))
+        val json = String(formBytes)
+        form = Typeform.json.decodeFromString(json)
     }
 }

--- a/typeform/src/commonMain/kotlin/com/typeform/Typeform.kt
+++ b/typeform/src/commonMain/kotlin/com/typeform/Typeform.kt
@@ -1,0 +1,16 @@
+package com.typeform
+
+import kotlinx.serialization.json.Json
+
+class Typeform {
+    companion object {
+        /**
+         * A preconfigured **kotlinx-serialization** Json Formatter.
+         */
+        val json: Json
+            get() = Json {
+                ignoreUnknownKeys = true
+                explicitNulls = false
+            }
+    }
+}

--- a/typeform/src/commonMain/kotlin/com/typeform/adapters/FlatAction.kt
+++ b/typeform/src/commonMain/kotlin/com/typeform/adapters/FlatAction.kt
@@ -5,6 +5,7 @@ import com.typeform.schema.ActionDetails
 import com.typeform.schema.ActionType
 import com.typeform.schema.Condition
 
+@Deprecated(message = "Use kotlinx-serialization.", replaceWith = ReplaceWith("ActionContract"))
 data class FlatAction(
     val action: ActionType,
     val details: ActionDetails,

--- a/typeform/src/commonMain/kotlin/com/typeform/adapters/FlatCondition.kt
+++ b/typeform/src/commonMain/kotlin/com/typeform/adapters/FlatCondition.kt
@@ -5,6 +5,7 @@ import com.typeform.schema.Op
 import com.typeform.schema.Var
 import com.typeform.schema.VarType
 
+@Deprecated(message = "Use kotlinx-serialization.", replaceWith = ReplaceWith("ConditionContract"))
 data class FlatCondition(
     val op: Op? = null,
     val vars: List<FlatCondition>? = null,

--- a/typeform/src/commonMain/kotlin/com/typeform/adapters/FlatField.kt
+++ b/typeform/src/commonMain/kotlin/com/typeform/adapters/FlatField.kt
@@ -5,6 +5,7 @@ import com.typeform.schema.FieldProperties
 import com.typeform.schema.FieldType
 import com.typeform.schema.Validations
 
+@Deprecated(message = "Use kotlinx-serialization.", replaceWith = ReplaceWith("FieldContract"))
 data class FlatField(
     val id: String,
     val ref: String,

--- a/typeform/src/commonMain/kotlin/com/typeform/adapters/FlatFieldProperties.kt
+++ b/typeform/src/commonMain/kotlin/com/typeform/adapters/FlatFieldProperties.kt
@@ -15,6 +15,7 @@ import com.typeform.schema.ShortText
 import com.typeform.schema.Statement
 import com.typeform.schema.YesNo
 
+@Deprecated(message = "Use kotlinx-serialization.", replaceWith = ReplaceWith("FieldPropertiesContract"))
 data class FlatFieldProperties(
     val description: String? = null,
     // Datestamp

--- a/typeform/src/commonMain/kotlin/com/typeform/adapters/FlatForm.kt
+++ b/typeform/src/commonMain/kotlin/com/typeform/adapters/FlatForm.kt
@@ -30,6 +30,7 @@ import com.typeform.schema.Workspace
  * }
  * ```
  */
+@Deprecated(message = "Use kotlinx-serialization.", replaceWith = ReplaceWith("FormContract"))
 data class FlatForm(
     val id: String,
     val type: FormType,

--- a/typeform/src/commonMain/kotlin/com/typeform/adapters/FlatLogic.kt
+++ b/typeform/src/commonMain/kotlin/com/typeform/adapters/FlatLogic.kt
@@ -4,6 +4,7 @@ import com.typeform.schema.Action
 import com.typeform.schema.Logic
 import com.typeform.schema.LogicType
 
+@Deprecated(message = "Use kotlinx-serialization.", replaceWith = ReplaceWith("LogicContract"))
 data class FlatLogic(
     val ref: String,
     val type: LogicType,

--- a/typeform/src/commonMain/kotlin/com/typeform/contracts/ActionContract.kt
+++ b/typeform/src/commonMain/kotlin/com/typeform/contracts/ActionContract.kt
@@ -1,0 +1,28 @@
+package com.typeform.contracts
+
+import com.typeform.schema.Action
+import com.typeform.schema.ActionDetails
+import com.typeform.schema.ActionType
+import com.typeform.schema.Condition
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ActionContract(
+    val action: ActionType,
+    val details: ActionDetails,
+    val condition: ConditionContract
+) {
+    constructor(action: Action): this(
+        action = action.action,
+        details = action.details,
+        condition = ConditionContract(action.condition),
+    )
+
+    fun toAction(): Action {
+        return Action(
+            action = action,
+            details = details,
+            condition = condition.toCondition() ?: Condition(),
+        )
+    }
+}

--- a/typeform/src/commonMain/kotlin/com/typeform/contracts/ConditionContract.kt
+++ b/typeform/src/commonMain/kotlin/com/typeform/contracts/ConditionContract.kt
@@ -1,0 +1,68 @@
+package com.typeform.contracts
+
+import com.typeform.schema.Condition
+import com.typeform.schema.Op
+import com.typeform.schema.Var
+import com.typeform.schema.VarType
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ConditionContract(
+    val op: Op?,
+    val vars: List<ConditionContract>?,
+    val type: VarType?,
+    val value: Var.Value?,
+) {
+    constructor(condition: Condition): this(
+        op = condition.op,
+        vars = when (condition.parameters) {
+                is Condition.Parameters.Vars -> {
+                    condition.parameters.vars.map { ConditionContract(it) }
+                }
+                is Condition.Parameters.Conditions -> {
+                    condition.parameters.conditions.map { ConditionContract(it) }
+                }
+            },
+        type = null,
+        value = null
+    )
+
+    constructor(`var`: Var): this(
+        op = null,
+        vars = null,
+        type = `var`.type,
+        value = `var`.value,
+    )
+
+    fun toCondition(): Condition? {
+        if (op != null && vars != null) {
+            val conditions = vars.mapNotNull { it.toCondition() }
+            val vars = vars.mapNotNull { it.toVar() }
+
+            return if (conditions.isNotEmpty()) {
+                Condition(
+                    op = op,
+                    parameters = Condition.Parameters.Conditions(conditions),
+                )
+            } else {
+                Condition(
+                    op = op,
+                    parameters = Condition.Parameters.Vars(vars)
+                )
+            }
+        }
+
+        return null
+    }
+
+    fun toVar(): Var? {
+        if (type != null && value != null) {
+            return Var(
+                type = type,
+                value = value
+            )
+        }
+
+        return null
+    }
+}

--- a/typeform/src/commonMain/kotlin/com/typeform/contracts/FieldContract.kt
+++ b/typeform/src/commonMain/kotlin/com/typeform/contracts/FieldContract.kt
@@ -1,0 +1,36 @@
+package com.typeform.contracts
+
+import com.typeform.schema.Field
+import com.typeform.schema.FieldType
+import com.typeform.schema.Validations
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class FieldContract(
+    val id: String,
+    val ref: String,
+    val type: FieldType,
+    val title: String,
+    val properties: FieldPropertiesContract,
+    val validations: Validations?,
+) {
+    constructor(field: Field): this(
+        id = field.id,
+        ref = field.ref,
+        type = field.type,
+        title = field.title,
+        properties = FieldPropertiesContract(field.properties),
+        validations = field.validations,
+    )
+
+    fun toField(): Field {
+        return Field(
+            id = id,
+            ref = ref,
+            type = type,
+            title = title,
+            properties = properties.toFieldProperties(type),
+            validations = validations,
+        )
+    }
+}

--- a/typeform/src/commonMain/kotlin/com/typeform/contracts/FieldPropertiesContract.kt
+++ b/typeform/src/commonMain/kotlin/com/typeform/contracts/FieldPropertiesContract.kt
@@ -1,0 +1,176 @@
+package com.typeform.contracts
+
+import com.typeform.schema.Choice
+import com.typeform.schema.DateStamp
+import com.typeform.schema.Dropdown
+import com.typeform.schema.FieldProperties
+import com.typeform.schema.FieldType
+import com.typeform.schema.Group
+import com.typeform.schema.LongText
+import com.typeform.schema.MultipleChoice
+import com.typeform.schema.Number
+import com.typeform.schema.OpinionScale
+import com.typeform.schema.Rating
+import com.typeform.schema.ShortText
+import com.typeform.schema.Statement
+import com.typeform.schema.YesNo
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class FieldPropertiesContract(
+    val description: String?,
+    // Datestamp
+    val separator: String?,
+    val structure: String?,
+    // Rating
+    val shape: String?,
+    // Rating, Opinion Scale
+    val steps: Int?,
+    // Opinion Scale
+    val labels: OpinionScale.Labels?,
+    @SerialName("start_at_one")
+    val startAtOne: Boolean?,
+    // Dropdown, Multiple Choice
+    val choices: List<Choice>?,
+    val randomize: Boolean?,
+    // Dropdown
+    @SerialName("alphabetical_order")
+    val alphabeticalOrder: Boolean?,
+    // Multiple Choice
+    @SerialName("allow_multiple_selection")
+    val allowMultipleSelection: Boolean?,
+    @SerialName("allow_other_choice")
+    val allowOtherChoice: Boolean?,
+    @SerialName("vertical_alignment")
+    val verticalAlignment: Boolean?,
+    // Group, Statement
+    @SerialName("button_text")
+    val buttonText: String?,
+    // Group
+    val fields: List<FieldContract>?,
+    @SerialName("show_button")
+    val showButton: Boolean?,
+    // Statement
+    @SerialName("hide_marks")
+    val hideMarks: Boolean?,
+) {
+    constructor(fieldProperties: FieldProperties): this(
+        description = fieldProperties.description,
+        separator = fieldProperties.separator,
+        structure = fieldProperties.structure,
+        shape = fieldProperties.shape,
+        steps = fieldProperties.steps,
+        labels = fieldProperties.labels,
+        startAtOne = fieldProperties.startAtOne,
+        choices = fieldProperties.choices,
+        randomize = fieldProperties.randomize,
+        alphabeticalOrder = fieldProperties.alphabeticalOrder,
+        allowMultipleSelection = fieldProperties.allowMultipleSelection,
+        allowOtherChoice = fieldProperties.allowOtherChoice,
+        verticalAlignment = fieldProperties.verticalAlignment,
+        buttonText = fieldProperties.buttonText,
+        fields = fieldProperties.fields?.map { FieldContract(it) },
+        showButton = fieldProperties.showButton,
+        hideMarks = fieldProperties.hideMarks,
+    )
+
+    fun toFieldProperties(type: FieldType): FieldProperties {
+        return when (type) {
+            FieldType.DATE -> {
+                FieldProperties.DateStampProperties(
+                    DateStamp(
+                        separator = separator ?: "",
+                        structure = structure ?: "",
+                        description = description,
+                    )
+                )
+            }
+            FieldType.DROPDOWN -> {
+                FieldProperties.DropdownProperties(
+                    Dropdown(
+                        choices = choices ?: emptyList(),
+                        randomize = randomize == true,
+                        alphabetical_order = alphabeticalOrder == true,
+                    )
+                )
+            }
+            FieldType.GROUP -> {
+                FieldProperties.GroupProperties(
+                    Group(
+                        button_text = buttonText ?: "",
+                        fields = fields?.map { it.toField() } ?: emptyList(),
+                        show_button = showButton == true,
+                    )
+                )
+            }
+            FieldType.LONG_TEXT -> {
+                FieldProperties.LongTextProperties(
+                    LongText(
+                        description = description,
+                    )
+                )
+            }
+            FieldType.MULTIPLE_CHOICE -> {
+                FieldProperties.MultipleChoiceProperties(
+                    MultipleChoice(
+                        choices = choices ?: emptyList(),
+                        randomize = randomize == true,
+                        allow_multiple_selection = allowMultipleSelection == true,
+                        allow_other_choice = allowOtherChoice == true,
+                        vertical_alignment = verticalAlignment == true,
+                        description = description,
+                    )
+                )
+            }
+            FieldType.NUMBER -> {
+                FieldProperties.NumberProperties(
+                    Number(
+                        description = description,
+                    )
+                )
+            }
+            FieldType.OPINION_SCALE -> {
+                FieldProperties.OpinionScaleProperties(
+                    OpinionScale(
+                        steps = steps ?: 0,
+                        labels = labels ?: OpinionScale.Labels(),
+                        start_at_one = startAtOne == true,
+                    )
+                )
+            }
+            FieldType.RATING -> {
+                FieldProperties.RatingProperties(
+                    Rating(
+                        shape = shape ?: "",
+                        steps = steps ?: 0,
+                        description = description,
+                    )
+                )
+            }
+            FieldType.SHORT_TEXT -> {
+                FieldProperties.ShortTextProperties(
+                    ShortText(
+                        description = description,
+                    )
+                )
+            }
+            FieldType.STATEMENT -> {
+                FieldProperties.StatementProperties(
+                    Statement(
+                        hide_marks = hideMarks == true,
+                        button_text = buttonText ?: "",
+                        description = description,
+                    )
+                )
+            }
+            FieldType.YES_NO -> {
+                FieldProperties.YesNoProperties(
+                    YesNo(
+                        description = description,
+                    )
+                )
+            }
+        }
+    }
+}

--- a/typeform/src/commonMain/kotlin/com/typeform/contracts/FormContract.kt
+++ b/typeform/src/commonMain/kotlin/com/typeform/contracts/FormContract.kt
@@ -1,0 +1,67 @@
+package com.typeform.contracts
+
+import com.typeform.schema.Form
+import com.typeform.schema.FormType
+import com.typeform.schema.Links
+import com.typeform.schema.Settings
+import com.typeform.schema.ThankYouScreen
+import com.typeform.schema.Theme
+import com.typeform.schema.WelcomeScreen
+import com.typeform.schema.Workspace
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * A version of [Form] with simplified & flattened structures that has been optimized
+ * for out-of-the-box de/serialization using **kotlinx-serialization**.
+ */
+@Serializable
+data class FormContract(
+    val id: String,
+    val type: FormType,
+    val logic: List<LogicContract>,
+    val theme: Theme,
+    val title: String,
+    @SerialName("_links")
+    val links: Links,
+    val fields: List<FieldContract>,
+    val hidden: List<String>?,
+    val settings: Settings,
+    val workspace: Workspace,
+    @SerialName("welcome_screens")
+    val welcomeScreens: List<WelcomeScreen>?,
+    @SerialName("thankyou_screens")
+    val thankYouScreens: List<ThankYouScreen>,
+) {
+    constructor(form: Form): this(
+        id = form.id,
+        type = form.type,
+        logic = form.logic.map { LogicContract(it) },
+        theme = form.theme,
+        title = form.title,
+        links = form._links,
+        fields = form.fields.map { FieldContract(it) },
+        hidden = form.hidden,
+        settings = form.settings,
+        workspace = form.workspace,
+        welcomeScreens = form.welcome_screens,
+        thankYouScreens = form.thankyou_screens,
+    )
+
+    fun toForm(): Form {
+        return Form(
+            id = id,
+            type = type,
+            logic = logic.map { it.toLogic() },
+            theme = theme,
+            title = title,
+            _links = links,
+            fields = fields.map { it.toField() },
+            hidden = hidden,
+            settings = settings,
+            workspace = workspace,
+            welcome_screens = welcomeScreens,
+            thankyou_screens = thankYouScreens,
+        )
+    }
+}

--- a/typeform/src/commonMain/kotlin/com/typeform/contracts/LogicContract.kt
+++ b/typeform/src/commonMain/kotlin/com/typeform/contracts/LogicContract.kt
@@ -1,0 +1,26 @@
+package com.typeform.contracts
+
+import com.typeform.schema.Logic
+import com.typeform.schema.LogicType
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class LogicContract(
+    val ref: String,
+    val type: LogicType,
+    val actions: List<ActionContract>
+) {
+    constructor(logic: Logic): this(
+        ref = logic.ref,
+        type = logic.type,
+        actions = logic.actions.map { ActionContract(it) }
+    )
+
+    fun toLogic(): Logic {
+        return Logic(
+            ref = ref,
+            type = type,
+            actions = actions.map { it.toAction() },
+        )
+    }
+}

--- a/typeform/src/commonMain/kotlin/com/typeform/schema/Action.kt
+++ b/typeform/src/commonMain/kotlin/com/typeform/schema/Action.kt
@@ -1,5 +1,9 @@
 package com.typeform.schema
 
+import com.typeform.serializers.ActionSerializer
+import kotlinx.serialization.Serializable
+
+@Serializable(with = ActionSerializer::class)
 data class Action(
     val action: ActionType,
     val details: ActionDetails,

--- a/typeform/src/commonMain/kotlin/com/typeform/schema/ActionDetails.kt
+++ b/typeform/src/commonMain/kotlin/com/typeform/schema/ActionDetails.kt
@@ -1,20 +1,26 @@
 package com.typeform.schema
 
+import com.typeform.serializers.ActionDetailsToTypeSerializer
+import kotlinx.serialization.Serializable
+
+@Serializable
 data class ActionDetails(
     val to: To,
 ) {
+    @Serializable
     data class To(
         val type: ToType,
         val value: String,
     )
 
+    @Serializable(with = ActionDetailsToTypeSerializer::class)
     enum class ToType(val rawValue: String) {
         FIELD("field"),
         THANK_YOU("thankyou"),
         ;
 
         companion object {
-            fun fromRawValue(rawValue: String) = ToType.values().associateBy(ToType::rawValue)[rawValue] ?: THANK_YOU
+            fun fromRawValue(rawValue: String) = ToType.entries.firstOrNull { it.rawValue == rawValue } ?: THANK_YOU
         }
     }
 }

--- a/typeform/src/commonMain/kotlin/com/typeform/schema/ActionType.kt
+++ b/typeform/src/commonMain/kotlin/com/typeform/schema/ActionType.kt
@@ -1,10 +1,14 @@
 package com.typeform.schema
 
+import com.typeform.serializers.ActionTypeSerializer
+import kotlinx.serialization.Serializable
+
+@Serializable(with = ActionTypeSerializer::class)
 enum class ActionType(val rawValue: String) {
     JUMP("jump"),
     ;
 
     companion object {
-        fun fromRawValue(rawValue: String) = ActionType.values().associateBy(ActionType::rawValue)[rawValue] ?: JUMP
+        fun fromRawValue(rawValue: String) = ActionType.entries.firstOrNull { it.rawValue == rawValue } ?: JUMP
     }
 }

--- a/typeform/src/commonMain/kotlin/com/typeform/schema/Choice.kt
+++ b/typeform/src/commonMain/kotlin/com/typeform/schema/Choice.kt
@@ -1,5 +1,8 @@
 package com.typeform.schema
 
+import kotlinx.serialization.Serializable
+
+@Serializable
 data class Choice(
     val id: String = "",
     val ref: String = "",

--- a/typeform/src/commonMain/kotlin/com/typeform/schema/Condition.kt
+++ b/typeform/src/commonMain/kotlin/com/typeform/schema/Condition.kt
@@ -1,7 +1,10 @@
 package com.typeform.schema
 
 import com.typeform.models.Responses
+import com.typeform.serializers.ConditionSerializer
+import kotlinx.serialization.Serializable
 
+@Serializable(with = ConditionSerializer::class)
 data class Condition(
     val op: Op = Op.EQUAL,
     val parameters: Parameters = Parameters.Conditions(emptyList()),
@@ -10,11 +13,11 @@ data class Condition(
     }
 
     sealed class Parameters {
-        companion object {
-        }
-
         data class Vars(val vars: List<Var>) : Parameters()
         data class Conditions(val conditions: List<Condition>) : Parameters()
+
+        companion object {
+        }
     }
 
     fun satisfiedGiven(responses: Responses): Boolean {

--- a/typeform/src/commonMain/kotlin/com/typeform/schema/DateStamp.kt
+++ b/typeform/src/commonMain/kotlin/com/typeform/schema/DateStamp.kt
@@ -1,5 +1,8 @@
 package com.typeform.schema
 
+import kotlinx.serialization.Serializable
+
+@Serializable
 data class DateStamp(
     val separator: String,
     val structure: String,

--- a/typeform/src/commonMain/kotlin/com/typeform/schema/Dropdown.kt
+++ b/typeform/src/commonMain/kotlin/com/typeform/schema/Dropdown.kt
@@ -1,5 +1,8 @@
 package com.typeform.schema
 
+import kotlinx.serialization.Serializable
+
+@Serializable
 data class Dropdown(
     val choices: List<Choice>,
     val randomize: Boolean,

--- a/typeform/src/commonMain/kotlin/com/typeform/schema/Field.kt
+++ b/typeform/src/commonMain/kotlin/com/typeform/schema/Field.kt
@@ -1,7 +1,10 @@
 package com.typeform.schema
 
 import com.typeform.models.Position
+import com.typeform.serializers.FieldSerializer
+import kotlinx.serialization.Serializable
 
+@Serializable(with = FieldSerializer::class)
 data class Field(
     val id: String,
     val ref: String,

--- a/typeform/src/commonMain/kotlin/com/typeform/schema/FieldProperties.kt
+++ b/typeform/src/commonMain/kotlin/com/typeform/schema/FieldProperties.kt
@@ -1,9 +1,6 @@
 package com.typeform.schema
 
 sealed class FieldProperties {
-    companion object {
-    }
-
     data class DateStampProperties(val properties: DateStamp) : FieldProperties()
     data class DropdownProperties(val properties: Dropdown) : FieldProperties()
     data class GroupProperties(val properties: Group) : FieldProperties()
@@ -15,6 +12,9 @@ sealed class FieldProperties {
     data class ShortTextProperties(val properties: ShortText) : FieldProperties()
     data class StatementProperties(val properties: Statement) : FieldProperties()
     data class YesNoProperties(val properties: YesNo) : FieldProperties()
+
+    companion object {
+    }
 
     fun asDateStamp(): DateStamp? {
         return when (this) {
@@ -136,4 +136,201 @@ sealed class FieldProperties {
             }
         }
     }
+
+    val description: String?
+        get() = when(this) {
+            is DateStampProperties -> {
+                this.properties.description
+            }
+            is LongTextProperties -> {
+                this.properties.description
+            }
+            is MultipleChoiceProperties -> {
+                this.properties.description
+            }
+            is NumberProperties -> {
+                this.properties.description
+            }
+            is RatingProperties -> {
+                this.properties.description
+            }
+            is StatementProperties -> {
+                this.properties.description
+            }
+            is YesNoProperties -> {
+                this.properties.description
+            }
+            else -> {
+                null
+            }
+        }
+
+    val separator: String?
+        get() = when(this) {
+            is DateStampProperties -> {
+                this.properties.separator
+            }
+            else -> {
+                null
+            }
+        }
+
+    val structure: String?
+        get() = when(this) {
+            is DateStampProperties -> {
+                this.properties.structure
+            }
+            else -> {
+                null
+            }
+        }
+
+    val shape: String?
+        get() = when(this) {
+            is RatingProperties -> {
+                this.properties.shape
+            }
+            else -> {
+                null
+            }
+        }
+
+    val steps: Int?
+        get() = when(this) {
+            is RatingProperties -> {
+                this.properties.steps
+            }
+            is OpinionScaleProperties -> {
+                this.properties.steps
+            }
+            else -> {
+                null
+            }
+        }
+
+    val labels: OpinionScale.Labels?
+        get() = when(this) {
+            is OpinionScaleProperties -> {
+                this.properties.labels
+            }
+            else -> {
+                null
+            }
+        }
+
+    val startAtOne: Boolean?
+        get() = when(this) {
+            is OpinionScaleProperties -> {
+                this.properties.start_at_one
+            }
+            else -> {
+                null
+            }
+        }
+
+    val choices: List<Choice>?
+        get() = when(this) {
+            is DropdownProperties -> {
+                this.properties.choices
+            }
+            is MultipleChoiceProperties -> {
+                this.properties.choices
+            }
+            else -> {
+                null
+            }
+        }
+
+    val randomize: Boolean?
+        get() = when(this) {
+            is DropdownProperties -> {
+                this.properties.randomize
+            }
+            is MultipleChoiceProperties -> {
+                this.properties.randomize
+            }
+            else -> {
+                null
+            }
+        }
+
+    val alphabeticalOrder: Boolean?
+        get() = when(this) {
+            is DropdownProperties -> {
+                this.properties.alphabetical_order
+            }
+            else -> {
+                null
+            }
+        }
+
+    val allowMultipleSelection: Boolean?
+        get() = when(this) {
+            is MultipleChoiceProperties -> {
+                this.properties.allow_multiple_selection
+            }
+            else -> {
+                null
+            }
+        }
+
+    val allowOtherChoice: Boolean?
+        get() = when(this) {
+            is MultipleChoiceProperties -> {
+                this.properties.allow_other_choice
+            }
+            else -> {
+                null
+            }
+        }
+
+    val verticalAlignment: Boolean?
+        get() = when(this) {
+            is MultipleChoiceProperties -> {
+                this.properties.vertical_alignment
+            }
+            else -> {
+                null
+            }
+        }
+
+    val buttonText: String?
+        get() = when(this) {
+            is StatementProperties -> {
+                this.properties.button_text
+            }
+            else -> {
+                null
+            }
+        }
+
+    val fields: List<Field>?
+        get() = when(this) {
+            is GroupProperties -> {
+                this.properties.fields
+            }
+            else -> {
+                null
+            }
+        }
+
+    val showButton: Boolean?
+        get() = when(this) {
+            is GroupProperties -> {
+                this.properties.show_button
+            }
+            else -> {
+                null
+            }
+        }
+
+    val hideMarks: Boolean?
+        get() = when(this) {
+            is StatementProperties -> {
+                this.properties.hide_marks
+            }
+            else -> {
+                null
+            }
+        }
 }

--- a/typeform/src/commonMain/kotlin/com/typeform/schema/FieldType.kt
+++ b/typeform/src/commonMain/kotlin/com/typeform/schema/FieldType.kt
@@ -1,5 +1,9 @@
 package com.typeform.schema
 
+import com.typeform.serializers.FieldTypeSerializer
+import kotlinx.serialization.Serializable
+
+@Serializable(with = FieldTypeSerializer::class)
 enum class FieldType(val rawValue: String) {
     DATE("date"),
     DROPDOWN("dropdown"),
@@ -15,6 +19,6 @@ enum class FieldType(val rawValue: String) {
     ;
 
     companion object {
-        fun fromRawValue(rawValue: String) = FieldType.values().associateBy(FieldType::rawValue)[rawValue] ?: STATEMENT
+        fun fromRawValue(rawValue: String) = FieldType.entries.firstOrNull { it.rawValue == rawValue } ?: STATEMENT
     }
 }

--- a/typeform/src/commonMain/kotlin/com/typeform/schema/Form.kt
+++ b/typeform/src/commonMain/kotlin/com/typeform/schema/Form.kt
@@ -4,7 +4,10 @@ import com.typeform.models.Position
 import com.typeform.models.Responses
 import com.typeform.models.TypeformException
 import com.typeform.models.responseRequiredFor
+import com.typeform.serializers.FormSerializer
+import kotlinx.serialization.Serializable
 
+@Serializable(with = FormSerializer::class)
 data class Form(
     val id: String,
     val type: FormType,

--- a/typeform/src/commonMain/kotlin/com/typeform/schema/FormType.kt
+++ b/typeform/src/commonMain/kotlin/com/typeform/schema/FormType.kt
@@ -1,10 +1,14 @@
 package com.typeform.schema
 
+import com.typeform.serializers.FormTypeSerializer
+import kotlinx.serialization.Serializable
+
+@Serializable(with = FormTypeSerializer::class)
 enum class FormType(val rawValue: String) {
     QUIZ("quiz"),
     ;
 
     companion object {
-        fun fromRawValue(rawValue: String) = FormType.values().associateBy(FormType::rawValue)[rawValue] ?: QUIZ
+        fun fromRawValue(rawValue: String) = FormType.entries.firstOrNull { it.rawValue == rawValue } ?: QUIZ
     }
 }

--- a/typeform/src/commonMain/kotlin/com/typeform/schema/Group.kt
+++ b/typeform/src/commonMain/kotlin/com/typeform/schema/Group.kt
@@ -1,5 +1,6 @@
 package com.typeform.schema
 
+
 data class Group(
     val button_text: String,
     val fields: List<Field>,

--- a/typeform/src/commonMain/kotlin/com/typeform/schema/Links.kt
+++ b/typeform/src/commonMain/kotlin/com/typeform/schema/Links.kt
@@ -1,7 +1,11 @@
 package com.typeform.schema
 
+import com.typeform.serializers.URLSerializer
+import kotlinx.serialization.Serializable
 import java.net.URL
 
+@Serializable
 data class Links(
+    @Serializable(with = URLSerializer::class)
     val display: URL,
 )

--- a/typeform/src/commonMain/kotlin/com/typeform/schema/Logic.kt
+++ b/typeform/src/commonMain/kotlin/com/typeform/schema/Logic.kt
@@ -1,5 +1,9 @@
 package com.typeform.schema
 
+import com.typeform.serializers.LogicSerializer
+import kotlinx.serialization.Serializable
+
+@Serializable(with = LogicSerializer::class)
 data class Logic(
     val ref: String,
     val type: LogicType,

--- a/typeform/src/commonMain/kotlin/com/typeform/schema/LogicType.kt
+++ b/typeform/src/commonMain/kotlin/com/typeform/schema/LogicType.kt
@@ -1,10 +1,14 @@
 package com.typeform.schema
 
+import com.typeform.serializers.LogicTypeSerializer
+import kotlinx.serialization.Serializable
+
+@Serializable(with = LogicTypeSerializer::class)
 enum class LogicType(val rawValue: String) {
     FIELD("field"),
     ;
 
     companion object {
-        fun fromRawValue(rawValue: String) = LogicType.values().associateBy(LogicType::rawValue)[rawValue] ?: FIELD
+        fun fromRawValue(rawValue: String) = LogicType.entries.firstOrNull { it.rawValue == rawValue } ?: FIELD
     }
 }

--- a/typeform/src/commonMain/kotlin/com/typeform/schema/LongText.kt
+++ b/typeform/src/commonMain/kotlin/com/typeform/schema/LongText.kt
@@ -1,5 +1,8 @@
 package com.typeform.schema
 
+import kotlinx.serialization.Serializable
+
+@Serializable
 data class LongText(
     val description: String?,
 )

--- a/typeform/src/commonMain/kotlin/com/typeform/schema/MultipleChoice.kt
+++ b/typeform/src/commonMain/kotlin/com/typeform/schema/MultipleChoice.kt
@@ -1,5 +1,8 @@
 package com.typeform.schema
 
+import kotlinx.serialization.Serializable
+
+@Serializable
 data class MultipleChoice(
     val choices: List<Choice>,
     val randomize: Boolean,

--- a/typeform/src/commonMain/kotlin/com/typeform/schema/Number.kt
+++ b/typeform/src/commonMain/kotlin/com/typeform/schema/Number.kt
@@ -1,5 +1,8 @@
 package com.typeform.schema
 
+import kotlinx.serialization.Serializable
+
+@Serializable
 data class Number(
     val description: String?,
 )

--- a/typeform/src/commonMain/kotlin/com/typeform/schema/Op.kt
+++ b/typeform/src/commonMain/kotlin/com/typeform/schema/Op.kt
@@ -1,5 +1,10 @@
 package com.typeform.schema
 
+import android.R.attr.entries
+import com.typeform.serializers.OpSerializer
+import kotlinx.serialization.Serializable
+
+@Serializable(with = OpSerializer::class)
 enum class Op(val rawValue: String) {
     ALWAYS("always"),
     AND("and"),
@@ -14,6 +19,6 @@ enum class Op(val rawValue: String) {
     ;
 
     companion object {
-        fun fromRawValue(rawValue: String) = entries.associateBy(Op::rawValue)[rawValue] ?: ALWAYS
+        fun fromRawValue(rawValue: String) = Op.entries.firstOrNull { it.rawValue == rawValue } ?: ALWAYS
     }
 }

--- a/typeform/src/commonMain/kotlin/com/typeform/schema/OpinionScale.kt
+++ b/typeform/src/commonMain/kotlin/com/typeform/schema/OpinionScale.kt
@@ -1,10 +1,14 @@
 package com.typeform.schema
 
+import kotlinx.serialization.Serializable
+
+@Serializable
 data class OpinionScale(
     val steps: Int,
     val labels: Labels,
     val start_at_one: Boolean
 ) {
+    @Serializable
     data class Labels(
         val left: String = "",
         val right: String = "",

--- a/typeform/src/commonMain/kotlin/com/typeform/schema/Rating.kt
+++ b/typeform/src/commonMain/kotlin/com/typeform/schema/Rating.kt
@@ -1,5 +1,8 @@
 package com.typeform.schema
 
+import kotlinx.serialization.Serializable
+
+@Serializable
 data class Rating(
     val shape: String,
     val steps: Int,

--- a/typeform/src/commonMain/kotlin/com/typeform/schema/ScreenAttachment.kt
+++ b/typeform/src/commonMain/kotlin/com/typeform/schema/ScreenAttachment.kt
@@ -1,8 +1,12 @@
 package com.typeform.schema
 
+import com.typeform.serializers.URLSerializer
+import kotlinx.serialization.Serializable
 import java.net.URL
 
+@Serializable
 data class ScreenAttachment(
+    @Serializable(with = URLSerializer::class)
     val href: URL,
     val type: String,
 )

--- a/typeform/src/commonMain/kotlin/com/typeform/schema/ScreenProperties.kt
+++ b/typeform/src/commonMain/kotlin/com/typeform/schema/ScreenProperties.kt
@@ -1,5 +1,8 @@
 package com.typeform.schema
 
+import kotlinx.serialization.Serializable
+
+@Serializable
 data class ScreenProperties(
     val button_mode: String?,
     val button_text: String?,

--- a/typeform/src/commonMain/kotlin/com/typeform/schema/Settings.kt
+++ b/typeform/src/commonMain/kotlin/com/typeform/schema/Settings.kt
@@ -1,5 +1,8 @@
 package com.typeform.schema
 
+import kotlinx.serialization.Serializable
+
+@Serializable
 data class Settings(
     val meta: Meta,
     val is_trial: Boolean,
@@ -16,14 +19,17 @@ data class Settings(
     val show_typeform_branding: Boolean,
     val show_number_of_submissions: Boolean,
 ) {
+    @Serializable
     data class Meta(
         val allow_indexing: Boolean,
     )
 
+    @Serializable
     data class Capabilities(
         val e2e_encryption: EndToEndEncryption?,
     )
 
+    @Serializable
     data class EndToEndEncryption(
         val enabled: Boolean,
         val modifiable: Boolean,

--- a/typeform/src/commonMain/kotlin/com/typeform/schema/ShortText.kt
+++ b/typeform/src/commonMain/kotlin/com/typeform/schema/ShortText.kt
@@ -1,5 +1,8 @@
 package com.typeform.schema
 
+import kotlinx.serialization.Serializable
+
+@Serializable
 data class ShortText(
     val description: String?,
 )

--- a/typeform/src/commonMain/kotlin/com/typeform/schema/Statement.kt
+++ b/typeform/src/commonMain/kotlin/com/typeform/schema/Statement.kt
@@ -1,5 +1,8 @@
 package com.typeform.schema
 
+import kotlinx.serialization.Serializable
+
+@Serializable
 data class Statement(
     val hide_marks: Boolean,
     val button_text: String,

--- a/typeform/src/commonMain/kotlin/com/typeform/schema/ThankYouScreen.kt
+++ b/typeform/src/commonMain/kotlin/com/typeform/schema/ThankYouScreen.kt
@@ -1,5 +1,8 @@
 package com.typeform.schema
 
+import kotlinx.serialization.Serializable
+
+@Serializable
 data class ThankYouScreen(
     override val id: String,
     val ref: String,

--- a/typeform/src/commonMain/kotlin/com/typeform/schema/Theme.kt
+++ b/typeform/src/commonMain/kotlin/com/typeform/schema/Theme.kt
@@ -1,7 +1,11 @@
 package com.typeform.schema
 
+import com.typeform.serializers.URLSerializer
+import kotlinx.serialization.Serializable
 import java.net.URL
 
+@Serializable
 data class Theme(
+    @Serializable(with = URLSerializer::class)
     val href: URL,
 )

--- a/typeform/src/commonMain/kotlin/com/typeform/schema/Validations.kt
+++ b/typeform/src/commonMain/kotlin/com/typeform/schema/Validations.kt
@@ -1,5 +1,8 @@
 package com.typeform.schema
 
+import kotlinx.serialization.Serializable
+
+@Serializable
 data class Validations(
-    val required: Boolean,
+    val required: Boolean = false,
 )

--- a/typeform/src/commonMain/kotlin/com/typeform/schema/Var.kt
+++ b/typeform/src/commonMain/kotlin/com/typeform/schema/Var.kt
@@ -2,15 +2,15 @@ package com.typeform.schema
 
 import com.typeform.models.ResponseValue
 import com.typeform.models.Responses
+import com.typeform.serializers.VarValueSerializer
+import kotlinx.serialization.Serializable
 
 data class Var(
     val type: VarType,
     val value: Value,
 ) {
+    @Serializable(with = VarValueSerializer::class)
     sealed class Value {
-        companion object {
-        }
-
         data class Bool(val value: Boolean) : Value()
         data class Integer(val value: Int) : Value()
         data class RefOrString(val value: String) : Value()

--- a/typeform/src/commonMain/kotlin/com/typeform/schema/VarType.kt
+++ b/typeform/src/commonMain/kotlin/com/typeform/schema/VarType.kt
@@ -1,5 +1,9 @@
 package com.typeform.schema
 
+import com.typeform.serializers.VarTypeSerializer
+import kotlinx.serialization.Serializable
+
+@Serializable(with = VarTypeSerializer::class)
 enum class VarType(val rawValue: String) {
     CHOICE("choice"),
     CONSTANT("constant"),

--- a/typeform/src/commonMain/kotlin/com/typeform/schema/WelcomeScreen.kt
+++ b/typeform/src/commonMain/kotlin/com/typeform/schema/WelcomeScreen.kt
@@ -1,5 +1,8 @@
 package com.typeform.schema
 
+import kotlinx.serialization.Serializable
+
+@Serializable
 data class WelcomeScreen(
     override val id: String,
     val ref: String,

--- a/typeform/src/commonMain/kotlin/com/typeform/schema/Workspace.kt
+++ b/typeform/src/commonMain/kotlin/com/typeform/schema/Workspace.kt
@@ -1,7 +1,11 @@
 package com.typeform.schema
 
+import com.typeform.serializers.URLSerializer
+import kotlinx.serialization.Serializable
 import java.net.URL
 
+@Serializable
 data class Workspace(
+    @Serializable(with = URLSerializer::class)
     val href: URL,
 )

--- a/typeform/src/commonMain/kotlin/com/typeform/schema/YesNo.kt
+++ b/typeform/src/commonMain/kotlin/com/typeform/schema/YesNo.kt
@@ -1,5 +1,8 @@
 package com.typeform.schema
 
+import kotlinx.serialization.Serializable
+
+@Serializable
 data class YesNo(
     val description: String?,
 )

--- a/typeform/src/commonMain/kotlin/com/typeform/serializers/ActionDetailsToTypeSerializer.kt
+++ b/typeform/src/commonMain/kotlin/com/typeform/serializers/ActionDetailsToTypeSerializer.kt
@@ -1,0 +1,22 @@
+package com.typeform.serializers
+
+import com.typeform.schema.ActionDetails
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+
+object ActionDetailsToTypeSerializer : KSerializer<ActionDetails.ToType> {
+    override val descriptor: SerialDescriptor
+        get() = PrimitiveSerialDescriptor("ActionDetails.ToType", PrimitiveKind.STRING)
+
+    override fun serialize(encoder: Encoder, value: ActionDetails.ToType) {
+        encoder.encodeString(value.rawValue)
+    }
+
+    override fun deserialize(decoder: Decoder): ActionDetails.ToType {
+        return ActionDetails.ToType.fromRawValue(decoder.decodeString())
+    }
+}

--- a/typeform/src/commonMain/kotlin/com/typeform/serializers/ActionSerializer.kt
+++ b/typeform/src/commonMain/kotlin/com/typeform/serializers/ActionSerializer.kt
@@ -1,0 +1,24 @@
+package com.typeform.serializers
+
+import com.typeform.contracts.ActionContract
+import com.typeform.schema.Action
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+
+object ActionSerializer : KSerializer<Action> {
+
+    private val serializer = ActionContract.serializer()
+
+    override val descriptor: SerialDescriptor
+        get() = serializer.descriptor
+
+    override fun serialize(encoder: Encoder, value: Action) {
+        serializer.serialize(encoder, ActionContract(value))
+    }
+
+    override fun deserialize(decoder: Decoder): Action {
+        return serializer.deserialize(decoder).toAction()
+    }
+}

--- a/typeform/src/commonMain/kotlin/com/typeform/serializers/ActionTypeSerializer.kt
+++ b/typeform/src/commonMain/kotlin/com/typeform/serializers/ActionTypeSerializer.kt
@@ -1,0 +1,22 @@
+package com.typeform.serializers
+
+import com.typeform.schema.ActionType
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+
+object ActionTypeSerializer : KSerializer<ActionType> {
+    override val descriptor: SerialDescriptor
+        get() = PrimitiveSerialDescriptor("ActionType", PrimitiveKind.STRING)
+
+    override fun serialize(encoder: Encoder, value: ActionType) {
+        encoder.encodeString(value.rawValue)
+    }
+
+    override fun deserialize(decoder: Decoder): ActionType {
+        return ActionType.fromRawValue(decoder.decodeString())
+    }
+}

--- a/typeform/src/commonMain/kotlin/com/typeform/serializers/ConditionSerializer.kt
+++ b/typeform/src/commonMain/kotlin/com/typeform/serializers/ConditionSerializer.kt
@@ -1,0 +1,25 @@
+package com.typeform.serializers
+
+import com.typeform.contracts.ConditionContract
+import com.typeform.schema.Condition
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+
+object ConditionSerializer : KSerializer<Condition> {
+
+    private val serializer = ConditionContract.serializer()
+
+    override val descriptor: SerialDescriptor
+        get() = serializer.descriptor
+
+    override fun serialize(encoder: Encoder, value: Condition) {
+        serializer.serialize(encoder, ConditionContract(value))
+    }
+
+    override fun deserialize(decoder: Decoder): Condition {
+        TODO("What's happening here?")
+        return serializer.deserialize(decoder).toCondition() ?: Condition()
+    }
+}

--- a/typeform/src/commonMain/kotlin/com/typeform/serializers/FieldSerializer.kt
+++ b/typeform/src/commonMain/kotlin/com/typeform/serializers/FieldSerializer.kt
@@ -1,0 +1,24 @@
+package com.typeform.serializers
+
+import com.typeform.contracts.FieldContract
+import com.typeform.schema.Field
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+
+object FieldSerializer : KSerializer<Field> {
+
+    private val serializer = FieldContract.serializer()
+
+    override val descriptor: SerialDescriptor
+        get() = serializer.descriptor
+
+    override fun serialize(encoder: Encoder, value: Field) {
+        serializer.serialize(encoder, FieldContract(value))
+    }
+
+    override fun deserialize(decoder: Decoder): Field {
+        return serializer.deserialize(decoder).toField()
+    }
+}

--- a/typeform/src/commonMain/kotlin/com/typeform/serializers/FieldTypeSerializer.kt
+++ b/typeform/src/commonMain/kotlin/com/typeform/serializers/FieldTypeSerializer.kt
@@ -1,0 +1,22 @@
+package com.typeform.serializers
+
+import com.typeform.schema.FieldType
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+
+object FieldTypeSerializer : KSerializer<FieldType> {
+    override val descriptor: SerialDescriptor
+        get() = PrimitiveSerialDescriptor("FieldType", PrimitiveKind.STRING)
+
+    override fun serialize(encoder: Encoder, value: FieldType) {
+        encoder.encodeString(value.rawValue)
+    }
+
+    override fun deserialize(decoder: Decoder): FieldType {
+        return FieldType.fromRawValue(decoder.decodeString())
+    }
+}

--- a/typeform/src/commonMain/kotlin/com/typeform/serializers/FormSerializer.kt
+++ b/typeform/src/commonMain/kotlin/com/typeform/serializers/FormSerializer.kt
@@ -1,0 +1,24 @@
+package com.typeform.serializers
+
+import com.typeform.contracts.FormContract
+import com.typeform.schema.Form
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+
+object FormSerializer : KSerializer<Form> {
+
+    private val serializer = FormContract.serializer()
+
+    override val descriptor: SerialDescriptor
+        get() = serializer.descriptor
+
+    override fun serialize(encoder: Encoder, value: Form) {
+        serializer.serialize(encoder, FormContract(value))
+    }
+
+    override fun deserialize(decoder: Decoder): Form {
+        return serializer.deserialize(decoder).toForm()
+    }
+}

--- a/typeform/src/commonMain/kotlin/com/typeform/serializers/FormTypeSerializer.kt
+++ b/typeform/src/commonMain/kotlin/com/typeform/serializers/FormTypeSerializer.kt
@@ -1,0 +1,22 @@
+package com.typeform.serializers
+
+import com.typeform.schema.FormType
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+
+object FormTypeSerializer : KSerializer<FormType> {
+    override val descriptor: SerialDescriptor
+        get() = PrimitiveSerialDescriptor("FormType", PrimitiveKind.STRING)
+
+    override fun serialize(encoder: Encoder, value: FormType) {
+        encoder.encodeString(value.rawValue)
+    }
+
+    override fun deserialize(decoder: Decoder): FormType {
+        return FormType.fromRawValue(decoder.decodeString())
+    }
+}

--- a/typeform/src/commonMain/kotlin/com/typeform/serializers/LogicSerializer.kt
+++ b/typeform/src/commonMain/kotlin/com/typeform/serializers/LogicSerializer.kt
@@ -1,0 +1,24 @@
+package com.typeform.serializers
+
+import com.typeform.contracts.LogicContract
+import com.typeform.schema.Logic
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+
+object LogicSerializer : KSerializer<Logic> {
+
+    private val serializer = LogicContract.serializer()
+
+    override val descriptor: SerialDescriptor
+        get() = serializer.descriptor
+
+    override fun serialize(encoder: Encoder, value: Logic) {
+        serializer.serialize(encoder, LogicContract(value))
+    }
+
+    override fun deserialize(decoder: Decoder): Logic {
+        return serializer.deserialize(decoder).toLogic()
+    }
+}

--- a/typeform/src/commonMain/kotlin/com/typeform/serializers/LogicTypeSerializer.kt
+++ b/typeform/src/commonMain/kotlin/com/typeform/serializers/LogicTypeSerializer.kt
@@ -1,0 +1,22 @@
+package com.typeform.serializers
+
+import com.typeform.schema.LogicType
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+
+object LogicTypeSerializer : KSerializer<LogicType> {
+    override val descriptor: SerialDescriptor
+        get() = PrimitiveSerialDescriptor("LogicType", PrimitiveKind.STRING)
+
+    override fun serialize(encoder: Encoder, value: LogicType) {
+        encoder.encodeString(value.rawValue)
+    }
+
+    override fun deserialize(decoder: Decoder): LogicType {
+        return LogicType.fromRawValue(decoder.decodeString())
+    }
+}

--- a/typeform/src/commonMain/kotlin/com/typeform/serializers/OpSerializer.kt
+++ b/typeform/src/commonMain/kotlin/com/typeform/serializers/OpSerializer.kt
@@ -1,0 +1,22 @@
+package com.typeform.serializers
+
+import com.typeform.schema.Op
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+
+object OpSerializer : KSerializer<Op> {
+    override val descriptor: SerialDescriptor
+        get() = PrimitiveSerialDescriptor("Op", PrimitiveKind.STRING)
+
+    override fun serialize(encoder: Encoder, value: Op) {
+        encoder.encodeString(value.rawValue)
+    }
+
+    override fun deserialize(decoder: Decoder): Op {
+        return Op.fromRawValue(decoder.decodeString())
+    }
+}

--- a/typeform/src/commonMain/kotlin/com/typeform/serializers/URLSerializer.kt
+++ b/typeform/src/commonMain/kotlin/com/typeform/serializers/URLSerializer.kt
@@ -1,0 +1,22 @@
+package com.typeform.serializers
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import java.net.URL
+
+object URLSerializer : KSerializer<URL> {
+    override val descriptor: SerialDescriptor
+        get() = PrimitiveSerialDescriptor("URL", PrimitiveKind.STRING)
+
+    override fun serialize(encoder: Encoder, value: URL) {
+        encoder.encodeString(value.toString())
+    }
+
+    override fun deserialize(decoder: Decoder): URL {
+        return URL(decoder.decodeString())
+    }
+}

--- a/typeform/src/commonMain/kotlin/com/typeform/serializers/VarTypeSerializer.kt
+++ b/typeform/src/commonMain/kotlin/com/typeform/serializers/VarTypeSerializer.kt
@@ -1,0 +1,22 @@
+package com.typeform.serializers
+
+import com.typeform.schema.VarType
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+
+object VarTypeSerializer : KSerializer<VarType> {
+    override val descriptor: SerialDescriptor
+        get() = PrimitiveSerialDescriptor("VarType", PrimitiveKind.STRING)
+
+    override fun serialize(encoder: Encoder, value: VarType) {
+        encoder.encodeString(value.rawValue)
+    }
+
+    override fun deserialize(decoder: Decoder): VarType {
+        return VarType.fromRawValue(decoder.decodeString())
+    }
+}

--- a/typeform/src/commonMain/kotlin/com/typeform/serializers/VarValueSerializer.kt
+++ b/typeform/src/commonMain/kotlin/com/typeform/serializers/VarValueSerializer.kt
@@ -1,0 +1,52 @@
+package com.typeform.serializers
+
+import com.typeform.schema.Var
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.intOrNull
+
+object VarValueSerializer : KSerializer<Var.Value> {
+
+    private val serializer = JsonPrimitive.serializer()
+
+    override val descriptor: SerialDescriptor
+        get() = serializer.descriptor
+
+    override fun serialize(encoder: Encoder, value: Var.Value) {
+        when (value) {
+            is Var.Value.Bool -> {
+                serializer.serialize(encoder, JsonPrimitive(value.value))
+            }
+            is Var.Value.Integer -> {
+                serializer.serialize(encoder, JsonPrimitive(value.value))
+            }
+            is Var.Value.RefOrString -> {
+                serializer.serialize(encoder, JsonPrimitive(value.value))
+            }
+        }
+    }
+
+    override fun deserialize(decoder: Decoder): Var.Value {
+        val primitive = serializer.deserialize(decoder)
+
+        primitive.booleanOrNull?.let {
+            return Var.Value.Bool(it)
+        }
+
+        primitive.intOrNull?.let {
+            return Var.Value.Integer(it)
+        }
+
+        primitive.contentOrNull?.let {
+            return Var.Value.RefOrString(it)
+        }
+
+        throw SerializationException("Unknown Var.Value Type")
+    }
+}


### PR DESCRIPTION
# Description

Migrated from 'Moshi' to 'kotlinx-serialization'.

The high level goal here was to initially move from the older 'KAPT' system to 'KSP' for handling code generation for serialization. While Moshi does support KSP, it is only to a certain extent (and limits the language version that can be adopted). Trying to implement the newer system in a Kotlin Multi-platfom Project was proving to be difficult; enter 'kotlinx-serialization'.

**kotlinx-serialization** is a highly supported serialization framework that is an extension to the Kotlin standard library in the same way that coroutines are. It has first-class support form multi-platform projects, and supports the most recent language versions.

Internally this supports PATM-825