### PR TITLE
Determine Next Launched Effect

### DIFF
--- a/typeform/src/androidMain/kotlin/com/typeform/ui/preview/FieldPreview.kt
+++ b/typeform/src/androidMain/kotlin/com/typeform/ui/preview/FieldPreview.kt
@@ -6,6 +6,7 @@ import com.typeform.schema.Dropdown
 import com.typeform.schema.Field
 import com.typeform.schema.FieldProperties
 import com.typeform.schema.FieldType
+import com.typeform.schema.Statement
 import com.typeform.schema.Validations
 
 val Field.Companion.previewDate: Field
@@ -45,4 +46,20 @@ val Field.Companion.previewDropdown: Field
         validations = Validations(
             required = true,
         ),
+    )
+
+val Field.Companion.previewStatement: Field
+    get() = Field(
+        id = "A37F8750-3E16-4626-A09E-29E51162F625",
+        ref = "5F3AFEF7-55F1-4500-B13A-99606DA24780",
+        type = FieldType.STATEMENT,
+        title = "Please read carefully.",
+        properties = FieldProperties.StatementProperties(
+            properties = Statement(
+                hide_marks = false,
+                button_text = "Agree",
+                description = "You must agree to this statement in order to continue.",
+            ),
+        ),
+        validations = null,
     )

--- a/typeform/src/androidMain/kotlin/com/typeform/ui/preview/FormPreview.kt
+++ b/typeform/src/androidMain/kotlin/com/typeform/ui/preview/FormPreview.kt
@@ -24,8 +24,9 @@ val Form.Companion.preview: Form
             display = URL("https://www.typeform.com"),
         ),
         fields = listOf(
-            Field.previewDate,
+            Field.previewStatement,
             Field.previewDropdown,
+            Field.previewDate,
         ),
         hidden = emptyList(),
         settings = Settings(

--- a/typeform/src/androidMain/kotlin/com/typeform/ui/structure/FieldView.kt
+++ b/typeform/src/androidMain/kotlin/com/typeform/ui/structure/FieldView.kt
@@ -1,6 +1,5 @@
 package com.typeform.ui.structure
 
-import android.content.res.Resources
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -11,6 +10,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -48,6 +48,7 @@ import com.typeform.ui.preview.ThemePreview
 import com.typeform.ui.preview.preview
 import com.typeform.ui.preview.previewDate
 import com.typeform.ui.preview.previewDropdown
+import com.typeform.ui.preview.previewStatement
 
 /**
  * Structure used to display individual [Field] types.
@@ -107,6 +108,10 @@ internal fun FieldView(
 
         collectedResponses = currentResponses
 
+        determineNext()
+    }
+
+    LaunchedEffect(Unit) {
         determineNext()
     }
 
@@ -245,8 +250,6 @@ internal fun FieldView(
             }
         }
     }
-
-    determineNext()
 }
 
 @Preview(showBackground = true, showSystemUi = true)
@@ -255,7 +258,7 @@ private fun FieldViewPreview(
     @PreviewParameter(FieldParameterProvider::class) reference: String,
 ) {
     val form = Form.preview
-    val field = form.fieldWithRef(reference) ?: throw Resources.NotFoundException()
+    val field = form.fieldWithRef(reference) ?: throw Exception("Resource Not Found")
 
     ThemePreview {
         FieldView(
@@ -282,7 +285,8 @@ private fun FieldViewPreview(
 private class FieldParameterProvider : PreviewParameterProvider<String> {
     override val values: Sequence<String>
         get() = sequenceOf(
-            Field.previewDate.ref,
+            Field.previewStatement.ref,
             Field.previewDropdown.ref,
+            Field.previewDate.ref,
         )
 }


### PR DESCRIPTION
# Description

Adjusts the `FieldView` to use a `LaunchedEffect` in order to run the `determineNext()` function on _appearance_.

This is a slight behavioral change with updating the compose compiler/Kotlin versions.

Internal Reference: PATM-1095
