### PR TITLE
Field `LaunchedEffect`s

### DIFF
--- a/typeform/src/androidMain/kotlin/com/typeform/ui/fields/DateView.kt
+++ b/typeform/src/androidMain/kotlin/com/typeform/ui/fields/DateView.kt
@@ -12,6 +12,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.rememberDatePickerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -64,6 +65,10 @@ internal fun DateView(
     fun select(millis: Long?) {
         milliseconds = millis
 
+        updateState()
+    }
+
+    LaunchedEffect(Unit) {
         updateState()
     }
 
@@ -129,8 +134,6 @@ internal fun DateView(
             }
         }
     }
-
-    updateState()
 }
 
 @Preview(showBackground = true, showSystemUi = true)

--- a/typeform/src/androidMain/kotlin/com/typeform/ui/fields/LongTextView.kt
+++ b/typeform/src/androidMain/kotlin/com/typeform/ui/fields/LongTextView.kt
@@ -8,6 +8,7 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.material.OutlinedTextField
 import androidx.compose.material.TextFieldDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -56,6 +57,10 @@ internal fun LongTextView(
         updateState()
     }
 
+    LaunchedEffect(Unit) {
+        updateState()
+    }
+
     Column(
         verticalArrangement = Arrangement.spacedBy(settings.presentation.descriptionContentVerticalSpacing),
     ) {
@@ -81,8 +86,6 @@ internal fun LongTextView(
             ),
         )
     }
-
-    updateState()
 }
 
 @Preview(showBackground = true, showSystemUi = true)

--- a/typeform/src/androidMain/kotlin/com/typeform/ui/fields/MultipleChoiceView.kt
+++ b/typeform/src/androidMain/kotlin/com/typeform/ui/fields/MultipleChoiceView.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -79,6 +80,10 @@ internal fun MultipleChoiceView(
         updateState()
     }
 
+    LaunchedEffect(Unit) {
+        updateState()
+    }
+
     Column(
         verticalArrangement = Arrangement.spacedBy(settings.presentation.descriptionContentVerticalSpacing),
     ) {
@@ -104,8 +109,6 @@ internal fun MultipleChoiceView(
             }
         }
     }
-
-    updateState()
 }
 
 @Preview(showBackground = true)

--- a/typeform/src/androidMain/kotlin/com/typeform/ui/fields/NumberView.kt
+++ b/typeform/src/androidMain/kotlin/com/typeform/ui/fields/NumberView.kt
@@ -8,6 +8,7 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.material.OutlinedTextField
 import androidx.compose.material.TextFieldDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -57,6 +58,10 @@ internal fun NumberView(
         updateState()
     }
 
+    LaunchedEffect(Unit) {
+        updateState()
+    }
+
     Column(
         verticalArrangement = Arrangement.spacedBy(settings.presentation.descriptionContentVerticalSpacing),
     ) {
@@ -82,8 +87,6 @@ internal fun NumberView(
             ),
         )
     }
-
-    updateState()
 }
 
 @Preview(showBackground = true, showSystemUi = true)

--- a/typeform/src/androidMain/kotlin/com/typeform/ui/fields/OpinionScaleView.kt
+++ b/typeform/src/androidMain/kotlin/com/typeform/ui/fields/OpinionScaleView.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Slider
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -87,6 +88,10 @@ internal fun OpinionScaleView(
         updateState()
     }
 
+    LaunchedEffect(Unit) {
+        updateState()
+    }
+
     Column(
         verticalArrangement = Arrangement.spacedBy(settings.presentation.contentVerticalSpacing),
         horizontalAlignment = Alignment.CenterHorizontally,
@@ -126,8 +131,6 @@ internal fun OpinionScaleView(
             )
         }
     }
-
-    updateState()
 }
 
 @Preview(showBackground = true, showSystemUi = true)

--- a/typeform/src/androidMain/kotlin/com/typeform/ui/fields/RatingView.kt
+++ b/typeform/src/androidMain/kotlin/com/typeform/ui/fields/RatingView.kt
@@ -13,6 +13,7 @@ import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.outlined.Cloud
 import androidx.compose.material.icons.outlined.Star
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -82,6 +83,10 @@ internal fun RatingView(
         updateState()
     }
 
+    LaunchedEffect(Unit) {
+        updateState()
+    }
+
     Column(
         verticalArrangement = Arrangement.spacedBy(settings.presentation.descriptionContentVerticalSpacing),
     ) {
@@ -129,8 +134,6 @@ internal fun RatingView(
             }
         }
     }
-
-    updateState()
 }
 
 @Preview(showBackground = true, showSystemUi = true)

--- a/typeform/src/androidMain/kotlin/com/typeform/ui/fields/ShortTextView.kt
+++ b/typeform/src/androidMain/kotlin/com/typeform/ui/fields/ShortTextView.kt
@@ -7,6 +7,7 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.material.OutlinedTextField
 import androidx.compose.material.TextFieldDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -54,6 +55,10 @@ internal fun ShortTextView(
         updateState()
     }
 
+    LaunchedEffect(Unit) {
+        updateState()
+    }
+
     Column(
         verticalArrangement = Arrangement.spacedBy(settings.presentation.descriptionContentVerticalSpacing),
     ) {
@@ -78,8 +83,6 @@ internal fun ShortTextView(
             ),
         )
     }
-
-    updateState()
 }
 
 @Preview(showBackground = true, showSystemUi = true)

--- a/typeform/src/androidMain/kotlin/com/typeform/ui/fields/YesNoView.kt
+++ b/typeform/src/androidMain/kotlin/com/typeform/ui/fields/YesNoView.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -68,6 +69,10 @@ internal fun YesNoView(
         updateState()
     }
 
+    LaunchedEffect(Unit) {
+        updateState()
+    }
+
     Column(
         verticalArrangement = Arrangement.spacedBy(settings.presentation.descriptionContentVerticalSpacing),
     ) {
@@ -98,8 +103,6 @@ internal fun YesNoView(
             }
         }
     }
-
-    updateState()
 }
 
 @Preview(showBackground = true, showSystemUi = true)

--- a/typeform/src/androidMain/kotlin/com/typeform/ui/structure/FormView.kt
+++ b/typeform/src/androidMain/kotlin/com/typeform/ui/structure/FormView.kt
@@ -20,7 +20,7 @@ import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.material.TextButton
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.outlined.ArrowBack
+import androidx.compose.material.icons.automirrored.outlined.ArrowBack
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -126,8 +126,8 @@ fun FormView(
                         ) {
                             if (showBackNavigation) {
                                 Icon(
-                                    imageVector = Icons.Outlined.ArrowBack,
-                                    contentDescription = Icons.Outlined.ArrowBack.name,
+                                    imageVector = Icons.AutoMirrored.Outlined.ArrowBack,
+                                    contentDescription = Icons.AutoMirrored.Outlined.ArrowBack.name,
                                     modifier = Modifier.clickable {
                                         navigateUsing(NavigationAction.Back)
                                     },


### PR DESCRIPTION
# Description

Addendum to #13, the individual field views had _dangling_ function calls to determine initial state. These have all been moved to `LaunchedEffect` to run during the initial composition.

Internal Reference: PATM-1095

