### PR TITLE
Additional Decoding Tests

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -11,4 +11,3 @@ android.nonTransitiveRClass=true
 #MPP
 kotlin.mpp.enableCInteropCommonization=true
 kotlin.mpp.androidSourceSetLayoutVersion=2
-kotlin.mpp.androidGradlePluginCompatibility.nowarn=true

--- a/typeform/src/androidMain/kotlin/com/typeform/ui/models/ResponseState.kt
+++ b/typeform/src/androidMain/kotlin/com/typeform/ui/models/ResponseState.kt
@@ -3,6 +3,7 @@ package com.typeform.ui.models
 import com.typeform.models.ResponseValue
 import com.typeform.models.Responses
 import com.typeform.schema.Field
+import com.typeform.schema.FieldProperties
 
 data class ResponseState(
     val response: ResponseValue? = null,
@@ -13,6 +14,16 @@ data class ResponseState(
         responses: Responses,
     ) : this(
         response = responses[field.ref],
-        invalid = field.properties.asStatement() == null,
+        invalid = when (field.properties) {
+            is FieldProperties.GroupProperties -> {
+                false
+            }
+            is FieldProperties.StatementProperties -> {
+                false
+            }
+            else -> {
+                true
+            }
+        },
     )
 }

--- a/typeform/src/androidUnitTest/kotlin/com/typeform/DemoFormTests.kt
+++ b/typeform/src/androidUnitTest/kotlin/com/typeform/DemoFormTests.kt
@@ -1,0 +1,60 @@
+package com.typeform
+
+import com.typeform.models.Position
+import com.typeform.schema.FieldType
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.fail
+
+class DemoFormTests : TypeformTestCase() {
+
+    override val jsonResource: String
+        get() = "DemoForm.json"
+
+    @Test
+    fun testDecode() {
+        assertEquals("hu2FodCY", form.id)
+    }
+
+    @Test
+    fun testFormStart() {
+        var position = form.firstPosition(
+            skipWelcomeScreen = false,
+            responses = mutableMapOf(),
+        )
+
+        when (position) {
+            is Position.FieldPosition -> {
+                fail("Unexpected Position $position")
+            }
+            is Position.ScreenPosition -> {
+                assertEquals("iVVVXbYhFAqt", position.screen.id)
+            }
+        }
+
+        position = form.nextPosition(position, mutableMapOf())
+
+        when (position) {
+            is Position.FieldPosition -> {
+                assertEquals("UKrtkRy8EAY2", position.field.id)
+                assertEquals(FieldType.GROUP, position.field.type)
+            }
+            is Position.ScreenPosition -> {
+                fail("Unexpected Position $position")
+            }
+        }
+
+        position = form.nextPosition(position, mutableMapOf())
+
+        when (position) {
+            is Position.FieldPosition -> {
+                assertEquals("M6IDI3o5xRXu", position.field.id)
+                assertNotNull(position.group)
+            }
+            is Position.ScreenPosition -> {
+                fail("Unexpected Position $position")
+            }
+        }
+    }
+}

--- a/typeform/src/androidUnitTest/kotlin/com/typeform/ImageAttachmentTests.kt
+++ b/typeform/src/androidUnitTest/kotlin/com/typeform/ImageAttachmentTests.kt
@@ -1,0 +1,34 @@
+package com.typeform
+
+import com.typeform.models.Position
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.fail
+
+class ImageAttachmentTests : TypeformTestCase() {
+
+    override val jsonResource: String
+        get() = "ImageAttachment.json"
+
+    @Test
+    fun testDecode() {
+        assertEquals("bjyxIhXZ", form.id)
+    }
+
+    @Test
+    fun testFormStart() {
+        val firstPosition = form.firstPosition(
+            skipWelcomeScreen = false,
+            responses = mutableMapOf(),
+        )
+
+        when (firstPosition) {
+            is Position.FieldPosition -> {
+                assertEquals("21xteNrP8VJs", firstPosition.field.id)
+            }
+            is Position.ScreenPosition -> {
+                fail("Unexpected Position $firstPosition")
+            }
+        }
+    }
+}

--- a/typeform/src/androidUnitTest/resources/DemoForm.json
+++ b/typeform/src/androidUnitTest/resources/DemoForm.json
@@ -1,0 +1,1027 @@
+{
+  "id": "hu2FodCY",
+  "type": "quiz",
+  "title": "Demo Form 2025-01-15",
+  "workspace": {
+    "href": "https://api.typeform.com/workspaces/5PY2Nu"
+  },
+  "theme": {
+    "href": "https://api.typeform.com/themes/qHWOQ7"
+  },
+  "settings": {
+    "language": "en",
+    "progress_bar": "proportion",
+    "meta": {
+      "allow_indexing": false
+    },
+    "hide_navigation": false,
+    "is_public": true,
+    "is_trial": false,
+    "show_progress_bar": true,
+    "show_typeform_branding": true,
+    "are_uploads_public": false,
+    "show_time_to_complete": true,
+    "show_number_of_submissions": false,
+    "show_cookie_consent": false,
+    "show_question_number": true,
+    "show_key_hint_on_choices": true,
+    "autosave_progress": true,
+    "free_form_navigation": false,
+    "use_lead_qualification": false,
+    "pro_subdomain_enabled": false
+  },
+  "thankyou_screens": [
+    {
+      "id": "AAsgeOEBHWAC",
+      "ref": "thank-you-1-typeform",
+      "title": "Thanks for submitting your responses",
+      "type": "thankyou_screen",
+      "properties": {
+        "show_button": false,
+        "share_icons": false,
+        "button_mode": "default_redirect",
+        "button_text": "again",
+        "description": "Thank you"
+      }
+    },
+    {
+      "id": "A308ZjazcJQ6",
+      "ref": "thank-you-2-typeform",
+      "title": "Thank you for letting us know.",
+      "type": "thankyou_screen",
+      "properties": {
+        "show_button": false,
+        "share_icons": false,
+        "button_mode": "default_redirect",
+        "button_text": "again",
+        "description": "Thanks again"
+      }
+    },
+    {
+      "id": "DefaultTyScreen",
+      "ref": "default_tys",
+      "title": "Thanks for completing this typeform\nNow *create your own* — it's free, easy, \u0026 beautiful",
+      "type": "thankyou_screen",
+      "properties": {
+        "show_button": true,
+        "share_icons": false,
+        "button_mode": "default_redirect",
+        "button_text": "Create a *typeform*"
+      },
+      "attachment": {
+        "type": "image",
+        "href": "https://images.typeform.com/images/2dpnUBBkz2VN"
+      }
+    }
+  ],
+  "welcome_screens": [
+    {
+      "id": "iVVVXbYhFAqt",
+      "ref": "welcome-1-typeform",
+      "title": "Welcome to Typeform",
+      "properties": {
+        "show_button": true,
+        "button_text": "Start",
+        "description": "Demo Now"
+      }
+    }
+  ],
+  "fields": [
+    {
+      "id": "UKrtkRy8EAY2",
+      "title": "Several Typeform questions will follow",
+      "ref": "question-group-typeform",
+      "properties": {
+        "description": "Answers are appreciated",
+        "button_text": "Continue",
+        "show_button": true,
+        "fields": [
+          {
+            "id": "M6IDI3o5xRXu",
+            "title": "Do you enjoy using Typeform?",
+            "ref": "group-yes-no-typeform",
+            "properties": {
+              "description": "Yes/No Question"
+            },
+            "validations": {
+              "required": false
+            },
+            "type": "yes_no"
+          }
+        ]
+      },
+      "type": "group"
+    },
+    {
+      "id": "7BP0MLinDRSK",
+      "title": "We're sorry to hear that you aren't enjoying Typeform.",
+      "ref": "statement-typeform",
+      "properties": {
+        "description": "Let us know how we can do better!",
+        "button_text": "Okay",
+        "hide_marks": true
+      },
+      "type": "statement"
+    },
+    {
+      "id": "JmxJ5tpY1WQI",
+      "title": "Does Niceform look better than Typeform?",
+      "ref": "yes-no-typeform",
+      "properties": {
+        "description": "This is Niceform"
+      },
+      "validations": {
+        "required": true
+      },
+      "type": "yes_no"
+    },
+    {
+      "id": "t5R9fs0sl5mo",
+      "title": "How many times have you used Typeform?",
+      "ref": "number-typeform",
+      "properties": {
+        "description": "Number Input without min or max values"
+      },
+      "validations": {
+        "required": false
+      },
+      "type": "number"
+    },
+    {
+      "id": "n3hxAXv29P9b",
+      "title": "Pick a number between 1 and 100",
+      "ref": "number-min-max-typeform",
+      "properties": {
+        "description": "Number Input with min value of 1 and max value of 100"
+      },
+      "validations": {
+        "required": false,
+        "min_value": 1,
+        "max_value": 100
+      },
+      "type": "number"
+    },
+    {
+      "id": "gRxfXcvybjXL",
+      "title": "What was the date of your last Typeform submission?",
+      "ref": "date-typeform",
+      "properties": {
+        "description": "Provide the approximate month, day, and year",
+        "separator": "/",
+        "structure": "MMDDYYYY"
+      },
+      "validations": {
+        "required": false
+      },
+      "type": "date"
+    },
+    {
+      "id": "GD9E3EwWEJ1N",
+      "title": "How would you rate Typeform?",
+      "ref": "opinion-scale-typeform",
+      "properties": {
+        "description": "Required Opinion Scale 0-5 with left, center and right labels",
+        "start_at_one": false,
+        "steps": 6,
+        "labels": {
+          "left": "Left",
+          "center": "Center",
+          "right": "Right"
+        }
+      },
+      "validations": {
+        "required": true
+      },
+      "type": "opinion_scale"
+    },
+    {
+      "id": "KAKnlynjXK3x",
+      "title": "How would you rate this custom form?",
+      "ref": "opinion-scale-no-labels-typeform",
+      "properties": {
+        "description": "Optional Opinion Scale 1-10 without labels",
+        "start_at_one": true,
+        "steps": 10
+      },
+      "validations": {
+        "required": false
+      },
+      "type": "opinion_scale"
+    },
+    {
+      "id": "PrRVCB9NtZpG",
+      "title": "What is your preferred choice if you can pick only one?",
+      "ref": "single-choice-typeform",
+      "properties": {
+        "description": "Single Choice",
+        "randomize": false,
+        "allow_multiple_selection": false,
+        "allow_other_choice": false,
+        "vertical_alignment": true,
+        "choices": [
+          {
+            "id": "d5ArurLWRvs8",
+            "ref": "sex-assigned-at-birth-answer-male",
+            "label": "Choice 1"
+          },
+          {
+            "id": "3RTXiBQd5fjU",
+            "ref": "sex-assigned-at-birth-answer-female",
+            "label": "Choice 2"
+          },
+          {
+            "id": "ezuojAOeU0SV",
+            "ref": "e0832847-9553-49d0-b9e4-bb5b56571542",
+            "label": "Choice 3"
+          },
+          {
+            "id": "3B6F5r8letVK",
+            "ref": "3164b1b9-ebff-40d3-aa7a-97ec1c429f00",
+            "label": "Choice 4"
+          },
+          {
+            "id": "j2kt8CVQzk6P",
+            "ref": "71ff649e-d6da-40f1-b509-45afd5b40f01",
+            "label": "Choice 5"
+          },
+          {
+            "id": "d7PSkzMnmNJd",
+            "ref": "93409c27-4268-4eb6-a25b-2b4c49ed8e4e",
+            "label": "Choice 6"
+          },
+          {
+            "id": "4jYXN8TDDC5g",
+            "ref": "4b823147-16ed-4e16-a985-7fab5bc079b5",
+            "label": "Choice 7"
+          },
+          {
+            "id": "prjFE1sivGU2",
+            "ref": "2cbdc1f5-3f9b-497c-8045-02edd75b1842",
+            "label": "Choice 8"
+          },
+          {
+            "id": "Atoxcgx7dV1b",
+            "ref": "a5b4aad6-d59a-45c6-ac69-3da797b69a2f",
+            "label": "Choice 9"
+          },
+          {
+            "id": "mCBG49qPwnx6",
+            "ref": "79c2a289-5177-4a42-a358-070235235aad",
+            "label": "Choice 10"
+          },
+          {
+            "id": "2Pbv5ndecCNQ",
+            "ref": "3ea3a20e-a8fb-4538-92c3-c899c718de8d",
+            "label": "Choice 11"
+          },
+          {
+            "id": "s056SYi7qsaC",
+            "ref": "a2221797-2e9a-4747-b8ca-b93f785f76b7",
+            "label": "Choice 12"
+          },
+          {
+            "id": "7AhfqPbfPl6T",
+            "ref": "41eb405d-ef7d-4397-b0bc-6dbebf7a78ff",
+            "label": "Choice 13"
+          }
+        ]
+      },
+      "validations": {
+        "required": false
+      },
+      "type": "multiple_choice"
+    },
+    {
+      "id": "trIA73HjP2Ed",
+      "title": "What are your preferred choices if you can pick more than one?",
+      "ref": "multiple-choice-typeform",
+      "properties": {
+        "description": "Multiple Choice",
+        "randomize": true,
+        "allow_multiple_selection": true,
+        "allow_other_choice": true,
+        "vertical_alignment": true,
+        "choices": [
+          {
+            "id": "eaU2HUrNK6UI",
+            "ref": "97a4d38d-152a-4107-a9b9-4dedefe2c352",
+            "label": "Choice 1"
+          },
+          {
+            "id": "KNuLxFP67DiY",
+            "ref": "c1b6c214-e859-45d3-9ac7-f364b5dfea67",
+            "label": "Choice 2"
+          },
+          {
+            "id": "4x7nNsirXzjY",
+            "ref": "015fa49c-867e-4b70-a49a-e64af11a25b6",
+            "label": "Choice 3"
+          },
+          {
+            "id": "XHurflYOnxLd",
+            "ref": "3b6ec34c-ee7d-4eb2-8e73-257fc5b51dae",
+            "label": "Choice 4"
+          },
+          {
+            "id": "6EGnzXNL3dDH",
+            "ref": "3c9fb096-9f14-4887-be7b-4089b8b0f183",
+            "label": "Choice 5"
+          },
+          {
+            "id": "QUoh8CHTuh7m",
+            "ref": "80c3a505-55c0-4507-b038-d374f8cc2537",
+            "label": "Choice 6"
+          },
+          {
+            "id": "oH7a0T6ksua4",
+            "ref": "d3b49df2-03ec-4b80-9df5-66d38412a1c3",
+            "label": "Choice 7"
+          },
+          {
+            "id": "RZ2i82tgXxGO",
+            "ref": "35bfea7b-4e21-41da-b6f6-6bbaed82fc78",
+            "label": "Choice 8"
+          },
+          {
+            "id": "mZQYcl8Pv8ai",
+            "ref": "fe759efd-a142-4c58-a0ba-4eaf70d0f5c5",
+            "label": "Choice 9"
+          },
+          {
+            "id": "GDFg8jzmGrh2",
+            "ref": "f6c4cec6-7586-452a-ae57-daa7bdba74bb",
+            "label": "Choice 10"
+          },
+          {
+            "id": "AoMvBixavYIU",
+            "ref": "1e11582d-77d0-4ec0-b702-be3665457e32",
+            "label": "Choice 11"
+          },
+          {
+            "id": "yJ2h5Aa4hvWA",
+            "ref": "7a47db41-389b-46cd-923a-c755422c61a7",
+            "label": "Choice 12"
+          },
+          {
+            "id": "hCNcbMtp6kkg",
+            "ref": "7337327e-fc76-4740-a6a4-d82a5fbc2081",
+            "label": "Choice 13"
+          }
+        ]
+      },
+      "validations": {
+        "required": true,
+        "min_selection": 4,
+        "max_selection": 4
+      },
+      "type": "multiple_choice"
+    },
+    {
+      "id": "o0cye0lMrUcW",
+      "title": "What are your preferred selections if you can pick more than one?",
+      "ref": "select-dropdown-typeform",
+      "properties": {
+        "description": "Select Dropdown",
+        "randomize": false,
+        "alphabetical_order": false,
+        "choices": [
+          {
+            "id": "Ug3yOICPvQBU",
+            "ref": "8427e552-fc77-487a-95f7-0dabdad378c3",
+            "label": "Choice 1"
+          },
+          {
+            "id": "c3cifMeDkCkg",
+            "ref": "60d3d3fb-c506-48bb-893f-c49be2ae4564",
+            "label": "Choice 2"
+          },
+          {
+            "id": "osAGXR5RrTNH",
+            "ref": "542f48ca-0e13-4b3e-98f2-dc6a733df5ca",
+            "label": "Choice 3"
+          },
+          {
+            "id": "Z9vVm9N855kI",
+            "ref": "5ed9cd92-cd39-4f81-a432-51c8e3f1fa03",
+            "label": "Choice 4"
+          },
+          {
+            "id": "5Q9z0iQMBghE",
+            "ref": "f429a7ba-1152-4685-b2b6-9d48954ccb5d",
+            "label": "Choice 5"
+          },
+          {
+            "id": "DG52NBYaHQLu",
+            "ref": "458b3c14-ff18-4481-9c02-12ab4477e5c1",
+            "label": "Choice 6"
+          },
+          {
+            "id": "zqyKA5EdZ4zz",
+            "ref": "27a93fcc-fd91-47c9-98ee-47725480fb20",
+            "label": "Choice 7"
+          },
+          {
+            "id": "puasbatuPh9P",
+            "ref": "ae94edeb-f4d4-4dbb-9829-a331e8dacc5c",
+            "label": "Choice 8"
+          },
+          {
+            "id": "YmlaMim8DvAN",
+            "ref": "386b0b2a-d9bc-4f2c-a69d-5c7715c0b803",
+            "label": "Choice 9"
+          },
+          {
+            "id": "yZHBEDZhalxp",
+            "ref": "c25c9067-37af-43cf-8293-aa316fa7e077",
+            "label": "Choice 10"
+          },
+          {
+            "id": "yllDa8yH5NWd",
+            "ref": "9b00e50a-fe8a-4b1d-8226-f9a6d9eee3be",
+            "label": "Choice 11"
+          },
+          {
+            "id": "mKFD51AMW8Nc",
+            "ref": "1602e5b9-b1d1-4ad6-a040-fbc2b65f0678",
+            "label": "Choice 12"
+          },
+          {
+            "id": "ZhevX99Crsng",
+            "ref": "01789c8f-9ad1-496d-86c8-40639e4bbc14",
+            "label": "Choice 13"
+          }
+        ]
+      },
+      "validations": {
+        "required": false
+      },
+      "type": "dropdown"
+    },
+    {
+      "id": "uVd9KWczmiqY",
+      "title": "Please input some short text here",
+      "ref": "short-text-typeform",
+      "properties": {
+        "description": "Short Text Input"
+      },
+      "validations": {
+        "required": false
+      },
+      "type": "short_text"
+    },
+    {
+      "id": "gCx4CXfFPddk",
+      "title": "Please input some long text here",
+      "ref": "long-text-typeform",
+      "properties": {
+        "description": "Long Text Input"
+      },
+      "validations": {
+        "required": false
+      },
+      "type": "long_text"
+    }
+  ],
+  "logic": [
+    {
+      "type": "field",
+      "ref": "multiple-choice-typeform",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "select-dropdown-typeform"
+            }
+          },
+          "condition": {
+            "op": "is_not",
+            "vars": [
+              {
+                "type": "field",
+                "value": "multiple-choice-typeform"
+              },
+              {
+                "type": "choice",
+                "value": "7337327e-fc76-4740-a6a4-d82a5fbc2081"
+              }
+            ]
+          }
+        },
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "thankyou",
+              "value": "default_tys"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "field",
+      "ref": "short-text-typeform",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "thankyou",
+              "value": "thank-you-2-typeform"
+            }
+          },
+          "condition": {
+            "op": "begins_with",
+            "vars": [
+              {
+                "type": "field",
+                "value": "short-text-typeform"
+              },
+              {
+                "type": "constant",
+                "value": "jump"
+              }
+            ]
+          }
+        },
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "long-text-typeform"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "field",
+      "ref": "opinion-scale-no-labels-typeform",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "single-choice-typeform"
+            }
+          },
+          "condition": {
+            "op": "and",
+            "vars": [
+              {
+                "op": "greater_equal_than",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "opinion-scale-no-labels-typeform"
+                  },
+                  {
+                    "type": "constant",
+                    "value": 1
+                  }
+                ]
+              },
+              {
+                "op": "lower_equal_than",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "opinion-scale-no-labels-typeform"
+                  },
+                  {
+                    "type": "constant",
+                    "value": 9
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "thankyou",
+              "value": "thank-you-2-typeform"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "field",
+      "ref": "number-min-max-typeform",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "thankyou",
+              "value": "thank-you-2-typeform"
+            }
+          },
+          "condition": {
+            "op": "or",
+            "vars": [
+              {
+                "op": "equal",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "number-min-max-typeform"
+                  },
+                  {
+                    "type": "constant",
+                    "value": 0
+                  }
+                ]
+              },
+              {
+                "op": "equal",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "number-min-max-typeform"
+                  },
+                  {
+                    "type": "constant",
+                    "value": 42
+                  }
+                ]
+              },
+              {
+                "op": "equal",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "number-min-max-typeform"
+                  },
+                  {
+                    "type": "constant",
+                    "value": 99
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "date-typeform"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "field",
+      "ref": "number-typeform",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "thankyou",
+              "value": "thank-you-2-typeform"
+            }
+          },
+          "condition": {
+            "op": "or",
+            "vars": [
+              {
+                "op": "equal",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "number-typeform"
+                  },
+                  {
+                    "type": "constant",
+                    "value": 42
+                  }
+                ]
+              },
+              {
+                "op": "equal",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "number-typeform"
+                  },
+                  {
+                    "type": "constant",
+                    "value": 99
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "number-min-max-typeform"
+            }
+          },
+          "condition": {
+            "op": "equal",
+            "vars": [
+              {
+                "type": "field",
+                "value": "number-typeform"
+              },
+              {
+                "type": "constant",
+                "value": 0
+              }
+            ]
+          }
+        },
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "date-typeform"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "field",
+      "ref": "opinion-scale-typeform",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "single-choice-typeform"
+            }
+          },
+          "condition": {
+            "op": "and",
+            "vars": [
+              {
+                "op": "greater_equal_than",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "opinion-scale-typeform"
+                  },
+                  {
+                    "type": "constant",
+                    "value": 1
+                  }
+                ]
+              },
+              {
+                "op": "lower_equal_than",
+                "vars": [
+                  {
+                    "type": "field",
+                    "value": "opinion-scale-typeform"
+                  },
+                  {
+                    "type": "constant",
+                    "value": 9
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "opinion-scale-no-labels-typeform"
+            }
+          },
+          "condition": {
+            "op": "equal",
+            "vars": [
+              {
+                "type": "field",
+                "value": "opinion-scale-typeform"
+              },
+              {
+                "type": "constant",
+                "value": 0
+              }
+            ]
+          }
+        },
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "thankyou",
+              "value": "thank-you-2-typeform"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "field",
+      "ref": "date-typeform",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "thankyou",
+              "value": "thank-you-2-typeform"
+            }
+          },
+          "condition": {
+            "op": "on",
+            "vars": [
+              {
+                "type": "field",
+                "value": "date-typeform"
+              },
+              {
+                "type": "constant",
+                "value": "2025-01-01"
+              }
+            ]
+          }
+        },
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "opinion-scale-typeform"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "field",
+      "ref": "group-yes-no-typeform",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "yes-no-typeform"
+            }
+          },
+          "condition": {
+            "op": "is",
+            "vars": [
+              {
+                "type": "field",
+                "value": "group-yes-no-typeform"
+              },
+              {
+                "type": "constant",
+                "value": false
+              }
+            ]
+          }
+        },
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "number-typeform"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "field",
+      "ref": "yes-no-typeform",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "thankyou",
+              "value": "thank-you-2-typeform"
+            }
+          },
+          "condition": {
+            "op": "is",
+            "vars": [
+              {
+                "type": "field",
+                "value": "yes-no-typeform"
+              },
+              {
+                "type": "constant",
+                "value": true
+              }
+            ]
+          }
+        },
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "statement-typeform"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "field",
+      "ref": "statement-typeform",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "thankyou",
+              "value": "thank-you-2-typeform"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    },
+    {
+      "type": "field",
+      "ref": "single-choice-typeform",
+      "actions": [
+        {
+          "action": "jump",
+          "details": {
+            "to": {
+              "type": "field",
+              "value": "multiple-choice-typeform"
+            }
+          },
+          "condition": {
+            "op": "always",
+            "vars": []
+          }
+        }
+      ]
+    }
+  ],
+  "_links": {
+    "display": "https://tohanuk.typeform.com/to/hu2FodCY",
+    "responses": "https://api.typeform.com/forms/hu2FodCY/responses"
+  }
+}

--- a/typeform/src/androidUnitTest/resources/ImageAttachment.json
+++ b/typeform/src/androidUnitTest/resources/ImageAttachment.json
@@ -1,0 +1,88 @@
+{
+  "id": "bjyxIhXZ",
+  "type": "quiz",
+  "title": "Async Prelim Test Form - Image Only",
+  "workspace": {
+    "href": "https://api.typeform.com/workspaces/5PY2Nu"
+  },
+  "theme": {
+    "href": "https://api.typeform.com/themes/qHWOQ7"
+  },
+  "settings": {
+    "language": "en",
+    "progress_bar": "proportion",
+    "meta": {
+      "allow_indexing": false
+    },
+    "hide_navigation": false,
+    "is_public": true,
+    "is_trial": false,
+    "show_progress_bar": true,
+    "show_typeform_branding": true,
+    "are_uploads_public": false,
+    "show_time_to_complete": true,
+    "show_number_of_submissions": false,
+    "show_cookie_consent": false,
+    "show_question_number": true,
+    "show_key_hint_on_choices": true,
+    "autosave_progress": true,
+    "free_form_navigation": false,
+    "use_lead_qualification": false,
+    "pro_subdomain_enabled": false
+  },
+  "thankyou_screens": [
+    {
+      "id": "DefaultTyScreen",
+      "ref": "default_tys",
+      "title": "Thanks for completing this typeform\nNow *create your own* — it's free, easy, \u0026 beautiful",
+      "type": "thankyou_screen",
+      "properties": {
+        "show_button": true,
+        "share_icons": false,
+        "button_mode": "default_redirect",
+        "button_text": "Create a *typeform*"
+      },
+      "attachment": {
+        "type": "image",
+        "href": "https://images.typeform.com/images/2dpnUBBkz2VN"
+      }
+    }
+  ],
+  "fields": [
+    {
+      "id": "21xteNrP8VJs",
+      "title": "This is a yes/no question with an image inserted below the description",
+      "ref": "8ef9c845-a658-4784-adfa-db703741df24",
+      "properties": {
+        "description": "Cool description"
+      },
+      "validations": {
+        "required": false
+      },
+      "type": "yes_no",
+      "attachment": {
+        "type": "image",
+        "href": "https://images.typeform.com/images/nicGuchsjTJG",
+        "properties": {
+          "decorative": false
+        }
+      },
+      "layout": {
+        "type": "stack",
+        "attachment": {
+          "type": "image",
+          "href": "https://images.typeform.com/images/nicGuchsjTJG",
+          "properties": {
+            "brightness": 0,
+            "decorative": false
+          }
+        },
+        "viewport_overrides": {}
+      }
+    }
+  ],
+  "_links": {
+    "display": "https://tohanuk.typeform.com/to/bjyxIhXZ",
+    "responses": "https://api.typeform.com/forms/bjyxIhXZ/responses"
+  }
+}

--- a/typeform/src/commonMain/kotlin/com/typeform/contracts/FormContract.kt
+++ b/typeform/src/commonMain/kotlin/com/typeform/contracts/FormContract.kt
@@ -19,7 +19,7 @@ import kotlinx.serialization.Serializable
 data class FormContract(
     val id: String,
     val type: FormType,
-    val logic: List<LogicContract>,
+    val logic: List<LogicContract>?,
     val theme: Theme,
     val title: String,
     @SerialName("_links")
@@ -52,7 +52,7 @@ data class FormContract(
         return Form(
             id = id,
             type = type,
-            logic = logic.map { it.toLogic() },
+            logic = (logic ?: emptyList()).map { it.toLogic() },
             theme = theme,
             title = title,
             _links = links,

--- a/typeform/src/commonMain/kotlin/com/typeform/models/TypeformException.kt
+++ b/typeform/src/commonMain/kotlin/com/typeform/models/TypeformException.kt
@@ -1,5 +1,7 @@
 package com.typeform.models
 
+import com.typeform.schema.Op
+
 sealed class TypeformException : Exception {
     private constructor() : super()
     private constructor(message: String) : super(message)
@@ -11,4 +13,8 @@ sealed class TypeformException : Exception {
     data object FirstPosition : TypeformException("The first position could not be determined.")
 
     data class NextPosition(val from: Position) : TypeformException("The next position could not be determined.")
+
+    data class UnexpectedOperation(val op: Op) : TypeformException("The Op was not expected at this time.")
+
+    data class ResponseTypeMismatch(val type: String) : TypeformException("A response had an unexpected type.")
 }

--- a/typeform/src/commonMain/kotlin/com/typeform/schema/ActionDetails.kt
+++ b/typeform/src/commonMain/kotlin/com/typeform/schema/ActionDetails.kt
@@ -17,10 +17,5 @@ data class ActionDetails(
     enum class ToType(val rawValue: String) {
         FIELD("field"),
         THANK_YOU("thankyou"),
-        ;
-
-        companion object {
-            fun fromRawValue(rawValue: String) = ToType.entries.firstOrNull { it.rawValue == rawValue } ?: THANK_YOU
-        }
     }
 }

--- a/typeform/src/commonMain/kotlin/com/typeform/schema/ActionType.kt
+++ b/typeform/src/commonMain/kotlin/com/typeform/schema/ActionType.kt
@@ -6,9 +6,4 @@ import kotlinx.serialization.Serializable
 @Serializable(with = ActionTypeSerializer::class)
 enum class ActionType(val rawValue: String) {
     JUMP("jump"),
-    ;
-
-    companion object {
-        fun fromRawValue(rawValue: String) = ActionType.entries.firstOrNull { it.rawValue == rawValue } ?: JUMP
-    }
 }

--- a/typeform/src/commonMain/kotlin/com/typeform/schema/FieldType.kt
+++ b/typeform/src/commonMain/kotlin/com/typeform/schema/FieldType.kt
@@ -16,9 +16,4 @@ enum class FieldType(val rawValue: String) {
     SHORT_TEXT("short_text"),
     STATEMENT("statement"),
     YES_NO("yes_no"),
-    ;
-
-    companion object {
-        fun fromRawValue(rawValue: String) = FieldType.entries.firstOrNull { it.rawValue == rawValue } ?: STATEMENT
-    }
 }

--- a/typeform/src/commonMain/kotlin/com/typeform/schema/Form.kt
+++ b/typeform/src/commonMain/kotlin/com/typeform/schema/Form.kt
@@ -170,7 +170,7 @@ data class Form(
             throw TypeformException.FirstPosition
         }
 
-        if (field.type == FieldType.STATEMENT) {
+        if (!responses.containsKey(field.ref)) {
             return Position.FieldPosition(field, null)
         }
 

--- a/typeform/src/commonMain/kotlin/com/typeform/schema/FormType.kt
+++ b/typeform/src/commonMain/kotlin/com/typeform/schema/FormType.kt
@@ -6,9 +6,4 @@ import kotlinx.serialization.Serializable
 @Serializable(with = FormTypeSerializer::class)
 enum class FormType(val rawValue: String) {
     QUIZ("quiz"),
-    ;
-
-    companion object {
-        fun fromRawValue(rawValue: String) = FormType.entries.firstOrNull { it.rawValue == rawValue } ?: QUIZ
-    }
 }

--- a/typeform/src/commonMain/kotlin/com/typeform/schema/LogicType.kt
+++ b/typeform/src/commonMain/kotlin/com/typeform/schema/LogicType.kt
@@ -6,9 +6,4 @@ import kotlinx.serialization.Serializable
 @Serializable(with = LogicTypeSerializer::class)
 enum class LogicType(val rawValue: String) {
     FIELD("field"),
-    ;
-
-    companion object {
-        fun fromRawValue(rawValue: String) = LogicType.entries.firstOrNull { it.rawValue == rawValue } ?: FIELD
-    }
 }

--- a/typeform/src/commonMain/kotlin/com/typeform/schema/Op.kt
+++ b/typeform/src/commonMain/kotlin/com/typeform/schema/Op.kt
@@ -1,24 +1,126 @@
 package com.typeform.schema
 
-import android.R.attr.entries
+import com.typeform.models.TypeformException
 import com.typeform.serializers.OpSerializer
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
 import kotlinx.serialization.Serializable
 
 @Serializable(with = OpSerializer::class)
 enum class Op(val rawValue: String) {
     ALWAYS("always"),
     AND("and"),
+    BEGINS_WITH("begins_with"),
+    CONTAINS("contains"),
+    EARLIER_THAN("earlier_than"),
+    EARLIER_THAN_OR_ON("earlier_than_or_on"),
+    ENDS_WITH("ends_with"),
     EQUAL("equal"),
     GREATER_EQUAL_THAN("greater_equal_than"),
     GREATER_THAN("greater_than"),
     IS("is"),
     IS_NOT("is_not"),
+    LATER_THAN("later_than"),
+    LATER_THAN_OR_ON("later_than_or_on"),
     LOWER_EQUAL_THAN("lower_equal_than"),
     LOWER_THAN("lower_than"),
+    NOT_CONTAINS("not_contains"),
+    NOT_ON("not_on"),
+    ON("on"),
     OR("or"),
     ;
 
     companion object {
-        fun fromRawValue(rawValue: String) = Op.entries.firstOrNull { it.rawValue == rawValue } ?: ALWAYS
+        private var yearMonthDay = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
+    }
+
+    @Throws(TypeformException.UnexpectedOperation::class)
+    fun compareString(
+        response: String,
+        condition: String,
+    ): Boolean {
+        when (this) {
+            BEGINS_WITH -> {
+                return response.startsWith(condition)
+            }
+            CONTAINS -> {
+                return response.contains(condition)
+            }
+            ENDS_WITH -> {
+                return response.endsWith(condition)
+            }
+            EQUAL -> {
+                return response == condition
+            }
+            NOT_CONTAINS -> {
+                return !response.contains(condition)
+            }
+            else -> {
+                throw TypeformException.UnexpectedOperation(this)
+            }
+        }
+    }
+
+    @Throws(TypeformException.UnexpectedOperation::class)
+    fun compareInt(
+        response: Int,
+        condition: Int,
+    ): Boolean {
+        when (this) {
+            EQUAL -> {
+                return response == condition
+            }
+            GREATER_EQUAL_THAN -> {
+                return response >= condition
+            }
+            GREATER_THAN -> {
+                return response > condition
+            }
+            LOWER_EQUAL_THAN -> {
+                return response <= condition
+            }
+            LOWER_THAN -> {
+                return response < condition
+            }
+            else -> {
+                throw TypeformException.UnexpectedOperation(this)
+            }
+        }
+    }
+
+    @Throws(TypeformException::class)
+    fun compareDate(
+        response: Date,
+        condition: String,
+    ): Boolean {
+        val conditionDate = yearMonthDay.parse(condition)
+            ?: throw TypeformException.ResponseTypeMismatch(Date::class.simpleName ?: "Date")
+
+        val comparison = response.compareTo(conditionDate)
+
+        when (this) {
+            EARLIER_THAN -> {
+                return comparison < 0
+            }
+            EARLIER_THAN_OR_ON -> {
+                return comparison <= 0
+            }
+            LATER_THAN -> {
+                return comparison > 0
+            }
+            LATER_THAN_OR_ON -> {
+                return comparison >= 0
+            }
+            NOT_ON -> {
+                return comparison != 0
+            }
+            ON -> {
+                return comparison == 0
+            }
+            else -> {
+                throw TypeformException.UnexpectedOperation(this)
+            }
+        }
     }
 }

--- a/typeform/src/commonMain/kotlin/com/typeform/schema/Var.kt
+++ b/typeform/src/commonMain/kotlin/com/typeform/schema/Var.kt
@@ -54,25 +54,10 @@ fun List<Var>.matchGiven(
         is Var.Value.Integer -> {
             return when (response) {
                 is ResponseValue.IntValue -> {
-                    when (op) {
-                        Op.EQUAL -> {
-                            response.value == valueVar.value.value
-                        }
-                        Op.GREATER_EQUAL_THAN -> {
-                            response.value >= valueVar.value.value
-                        }
-                        Op.GREATER_THAN -> {
-                            response.value > valueVar.value.value
-                        }
-                        Op.LOWER_EQUAL_THAN -> {
-                            response.value <= valueVar.value.value
-                        }
-                        Op.LOWER_THAN -> {
-                            response.value < valueVar.value.value
-                        }
-                        else -> {
-                            null
-                        }
+                    try {
+                        op.compareInt(response.value, valueVar.value.value)
+                    } catch (_: Exception) {
+                        null
                     }
                 }
                 else -> {
@@ -89,7 +74,18 @@ fun List<Var>.matchGiven(
                     response.value.map { it.ref }.contains(valueVar.value.value)
                 }
                 is ResponseValue.StringValue -> {
-                    response.value == valueVar.value.value
+                    try {
+                        op.compareString(response.value, valueVar.value.value)
+                    } catch (_: Exception) {
+                        null
+                    }
+                }
+                is ResponseValue.DateValue -> {
+                    try {
+                        op.compareDate(response.value, valueVar.value.value)
+                    } catch (_: Exception) {
+                        null
+                    }
                 }
                 else -> {
                     null

--- a/typeform/src/commonMain/kotlin/com/typeform/schema/VarType.kt
+++ b/typeform/src/commonMain/kotlin/com/typeform/schema/VarType.kt
@@ -8,9 +8,4 @@ enum class VarType(val rawValue: String) {
     CHOICE("choice"),
     CONSTANT("constant"),
     FIELD("field"),
-    ;
-
-    companion object {
-        fun fromRawValue(rawValue: String) = VarType.entries.firstOrNull { it.rawValue == rawValue } ?: CONSTANT
-    }
 }

--- a/typeform/src/commonMain/kotlin/com/typeform/serializers/ActionDetailsToTypeSerializer.kt
+++ b/typeform/src/commonMain/kotlin/com/typeform/serializers/ActionDetailsToTypeSerializer.kt
@@ -2,6 +2,7 @@ package com.typeform.serializers
 
 import com.typeform.schema.ActionDetails
 import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerializationException
 import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
 import kotlinx.serialization.descriptors.SerialDescriptor
@@ -20,6 +21,8 @@ object ActionDetailsToTypeSerializer : KSerializer<ActionDetails.ToType> {
     }
 
     override fun deserialize(decoder: Decoder): ActionDetails.ToType {
-        return ActionDetails.ToType.fromRawValue(decoder.decodeString())
+        val rawValue = decoder.decodeString()
+        return ActionDetails.ToType.entries.firstOrNull { it.rawValue == rawValue }
+            ?: throw SerializationException("Unhandled 'ActionDetails.ToType' value '$rawValue'.")
     }
 }

--- a/typeform/src/commonMain/kotlin/com/typeform/serializers/ActionTypeSerializer.kt
+++ b/typeform/src/commonMain/kotlin/com/typeform/serializers/ActionTypeSerializer.kt
@@ -2,6 +2,7 @@ package com.typeform.serializers
 
 import com.typeform.schema.ActionType
 import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerializationException
 import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
 import kotlinx.serialization.descriptors.SerialDescriptor
@@ -20,6 +21,8 @@ object ActionTypeSerializer : KSerializer<ActionType> {
     }
 
     override fun deserialize(decoder: Decoder): ActionType {
-        return ActionType.fromRawValue(decoder.decodeString())
+        val rawValue = decoder.decodeString()
+        return ActionType.entries.firstOrNull { it.rawValue == rawValue }
+            ?: throw SerializationException("Unhandled 'ActionType' value '$rawValue'.")
     }
 }

--- a/typeform/src/commonMain/kotlin/com/typeform/serializers/FieldTypeSerializer.kt
+++ b/typeform/src/commonMain/kotlin/com/typeform/serializers/FieldTypeSerializer.kt
@@ -2,6 +2,7 @@ package com.typeform.serializers
 
 import com.typeform.schema.FieldType
 import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerializationException
 import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
 import kotlinx.serialization.descriptors.SerialDescriptor
@@ -20,6 +21,8 @@ object FieldTypeSerializer : KSerializer<FieldType> {
     }
 
     override fun deserialize(decoder: Decoder): FieldType {
-        return FieldType.fromRawValue(decoder.decodeString())
+        val rawValue = decoder.decodeString()
+        return FieldType.entries.firstOrNull { it.rawValue == rawValue }
+            ?: throw SerializationException("Unhandled 'FieldType' value '$rawValue'.")
     }
 }

--- a/typeform/src/commonMain/kotlin/com/typeform/serializers/FormTypeSerializer.kt
+++ b/typeform/src/commonMain/kotlin/com/typeform/serializers/FormTypeSerializer.kt
@@ -2,6 +2,7 @@ package com.typeform.serializers
 
 import com.typeform.schema.FormType
 import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerializationException
 import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
 import kotlinx.serialization.descriptors.SerialDescriptor
@@ -20,6 +21,8 @@ object FormTypeSerializer : KSerializer<FormType> {
     }
 
     override fun deserialize(decoder: Decoder): FormType {
-        return FormType.fromRawValue(decoder.decodeString())
+        val rawValue = decoder.decodeString()
+        return FormType.entries.firstOrNull { it.rawValue == rawValue }
+            ?: throw SerializationException("Unhandled 'FormType' value '$rawValue'.")
     }
 }

--- a/typeform/src/commonMain/kotlin/com/typeform/serializers/LogicTypeSerializer.kt
+++ b/typeform/src/commonMain/kotlin/com/typeform/serializers/LogicTypeSerializer.kt
@@ -2,6 +2,7 @@ package com.typeform.serializers
 
 import com.typeform.schema.LogicType
 import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerializationException
 import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
 import kotlinx.serialization.descriptors.SerialDescriptor
@@ -20,6 +21,8 @@ object LogicTypeSerializer : KSerializer<LogicType> {
     }
 
     override fun deserialize(decoder: Decoder): LogicType {
-        return LogicType.fromRawValue(decoder.decodeString())
+        val rawValue = decoder.decodeString()
+        return LogicType.entries.firstOrNull { it.rawValue == rawValue }
+            ?: throw SerializationException("Unhandled 'LogicType' value '$rawValue'.")
     }
 }

--- a/typeform/src/commonMain/kotlin/com/typeform/serializers/OpSerializer.kt
+++ b/typeform/src/commonMain/kotlin/com/typeform/serializers/OpSerializer.kt
@@ -2,6 +2,7 @@ package com.typeform.serializers
 
 import com.typeform.schema.Op
 import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerializationException
 import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
 import kotlinx.serialization.descriptors.SerialDescriptor
@@ -20,6 +21,8 @@ object OpSerializer : KSerializer<Op> {
     }
 
     override fun deserialize(decoder: Decoder): Op {
-        return Op.fromRawValue(decoder.decodeString())
+        val rawValue = decoder.decodeString()
+        return Op.entries.firstOrNull { it.rawValue == rawValue }
+            ?: throw SerializationException("Unhandled 'Op' value '$rawValue'.")
     }
 }

--- a/typeform/src/commonMain/kotlin/com/typeform/serializers/VarTypeSerializer.kt
+++ b/typeform/src/commonMain/kotlin/com/typeform/serializers/VarTypeSerializer.kt
@@ -2,6 +2,7 @@ package com.typeform.serializers
 
 import com.typeform.schema.VarType
 import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerializationException
 import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
 import kotlinx.serialization.descriptors.SerialDescriptor
@@ -20,6 +21,8 @@ object VarTypeSerializer : KSerializer<VarType> {
     }
 
     override fun deserialize(decoder: Decoder): VarType {
-        return VarType.fromRawValue(decoder.decodeString())
+        val rawValue = decoder.decodeString()
+        return VarType.entries.firstOrNull { it.rawValue == rawValue }
+            ?: throw SerializationException("Unhandled 'VarType' value '$rawValue'.")
     }
 }


### PR DESCRIPTION
# Description

Adds some additional example Form json documents to test decoding against. There were a few `Op` (Operation) comparison options that weren't being accounted for. Also, updated the Form deserialization to fail on unexpected enumerations rather than supplying a _default_ value (hiding errors).

