### PR TITLE
File Upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ All of the _structural_ components are supported: Welcome Screen, Ending, Statem
 
 * Date
 * Dropdown
+* File Upload
 * Long Text
 * Opinion Scale
 * Multiple Choice
@@ -127,6 +128,36 @@ All of the _structural_ components are supported: Welcome Screen, Ending, Statem
 * Rating
 * Short Text
 * Yes/No
+
+### File Upload
+
+To enable the broadest support for file uploading a `UploadHelper` should be supplied to the `FormView` when initialized.
+The helper is responsible for creating writable `Uri`s for camera capture and for creating `Bitmap` representations for display.
+Your app manifest should include the following to support uploading:
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" xmlns:tools="http://schemas.android.com/tools">
+  <uses-feature
+    android:name="android.hardware.camera"
+    android:required="false" />
+
+  <uses-permission android:name="android.permission.CAMERA" />
+
+  <application>
+    <provider
+      android:name="androidx.core.content.FileProvider"
+      android:authorities="${applicationId}"
+      android:grantUriPermissions="true"
+      android:exported="false"
+      tools:replace="android:authorities">
+      <meta-data
+        android:name="android.support.FILE_PROVIDER_PATHS"
+        android:resource="@xml/file_paths"/>
+    </provider>
+  </application>
+</manifest>
+```
 
 ## Customization
 

--- a/example/build.gradle.kts
+++ b/example/build.gradle.kts
@@ -47,6 +47,7 @@ dependencies {
     debugImplementation(libs.androidx.ui.tooling)
     implementation(libs.coil.compose)
     implementation(libs.coil.network)
+    implementation(libs.google.accompanist)
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.ktor.android)
     implementation(libs.ktor.client)

--- a/example/src/main/AndroidManifest.xml
+++ b/example/src/main/AndroidManifest.xml
@@ -2,7 +2,12 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-feature
+        android:name="android.hardware.camera"
+        android:required="false" />
+
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.CAMERA" />
 
     <application
         android:allowBackup="true"
@@ -24,6 +29,17 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}"
+            android:grantUriPermissions="true"
+            android:exported="false"
+            tools:replace="android:authorities">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths"/>
+        </provider>
     </application>
 
 </manifest>

--- a/example/src/main/java/com/typeform/example/model/ExampleUploadHelper.kt
+++ b/example/src/main/java/com/typeform/example/model/ExampleUploadHelper.kt
@@ -1,0 +1,61 @@
+package com.typeform.example.model
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.net.Uri
+import androidx.core.content.FileProvider
+import com.google.accompanist.permissions.ExperimentalPermissionsApi
+import com.google.accompanist.permissions.PermissionState
+import com.google.accompanist.permissions.PermissionStatus
+import com.google.accompanist.permissions.shouldShowRationale
+import com.typeform.models.Upload
+import com.typeform.ui.models.UploadHelper
+import java.io.File
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+
+class ExampleUploadHelper @OptIn(ExperimentalPermissionsApi::class) constructor(
+    val cameraPermissionState: PermissionState
+) : UploadHelper {
+    override val allowedDocumentTypes: Array<String>
+        get() = arrayOf(
+            "image/jpeg",
+            "image/png",
+            "application/pdf",
+        )
+
+    @OptIn(ExperimentalUuidApi::class, ExperimentalPermissionsApi::class)
+    override fun uriForCameraImage(context: Context): Result<Uri?> {
+        when (cameraPermissionState.status) {
+            is PermissionStatus.Denied -> {
+                if (cameraPermissionState.status.shouldShowRationale) {
+                    return Result.failure(Exception("Camera Permission Denied"))
+                } else {
+                    cameraPermissionState.launchPermissionRequest()
+                    return Result.success(null)
+                }
+            }
+            is PermissionStatus.Granted -> {
+                try {
+                    val directory = File(context.cacheDir, "images")
+                    directory.mkdirs()
+                    val file = File("${directory}/${Uuid.random()}.jpg")
+                    val uri = FileProvider.getUriForFile(context, context.packageName, file)
+                    return Result.success(uri)
+                } catch (exception: Exception) {
+                    return Result.failure(exception)
+                }
+            }
+        }
+    }
+
+    override fun bitmapForUpload(upload: Upload, context: Context): Result<Bitmap> {
+        val bitmap = BitmapFactory.decodeByteArray(upload.bytes, 0, upload.bytes.size)
+        return if (bitmap != null) {
+            Result.success(bitmap)
+        } else {
+            Result.failure(Exception("Bitmap Failed"))
+        }
+    }
+}

--- a/example/src/main/java/com/typeform/example/ui/content/Navigation.kt
+++ b/example/src/main/java/com/typeform/example/ui/content/Navigation.kt
@@ -1,5 +1,6 @@
 package com.typeform.example.ui.content
 
+import android.Manifest
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -12,12 +13,16 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import coil3.SingletonImageLoader
 import coil3.compose.LocalPlatformContext
+import com.google.accompanist.permissions.ExperimentalPermissionsApi
+import com.google.accompanist.permissions.rememberPermissionState
+import com.typeform.example.model.ExampleUploadHelper
 import com.typeform.example.ui.theme.ExampleTheme
 import com.typeform.schema.Form
 import com.typeform.ui.models.Conclusion
 import com.typeform.ui.models.Settings
 import com.typeform.ui.structure.FormView
 
+@OptIn(ExperimentalPermissionsApi::class)
 @Composable
 fun Navigation(
     modifier: Modifier = Modifier,
@@ -26,6 +31,7 @@ fun Navigation(
     var form: Form? by remember { mutableStateOf(null) }
     var settings: Settings by remember { mutableStateOf(Settings()) }
     var conclusion: Conclusion? by remember { mutableStateOf(null) }
+    val cameraPermissionState = rememberPermissionState(permission = Manifest.permission.CAMERA)
 
     NavHost(
         navController = navController,
@@ -53,6 +59,9 @@ fun Navigation(
                     form = it,
                     settings = settings,
                     imageLoader = SingletonImageLoader.get(LocalPlatformContext.current),
+                    uploadHelper = ExampleUploadHelper(
+                        cameraPermissionState = cameraPermissionState,
+                    ),
                     conclusion = {
                         conclusion = it
                         navController.navigate("content")

--- a/example/src/main/java/com/typeform/example/ui/content/ResponsesView.kt
+++ b/example/src/main/java/com/typeform/example/ui/content/ResponsesView.kt
@@ -45,6 +45,9 @@ fun ResponsesView(
                 is ResponseValue.StringValue -> {
                     Text(text = value.value)
                 }
+                is ResponseValue.UploadValue -> {
+                    Text(text = value.value.mimeType)
+                }
             }
         }
     }

--- a/example/src/main/res/xml/file_paths.xml
+++ b/example/src/main/res/xml/file_paths.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+    <cache-path name="camera_temp" path="images/"/>
+</paths>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,6 +5,7 @@ coil = "3.1.0"
 compose = "1.7.1"
 composeBom = "2025.01.01"
 coreKtx = "1.15.0"
+googleAccompanist = "0.37.0"
 kotlin = "2.1.0"
 kotlinxSerializationJson = "1.7.3"
 ktlint = "12.1.1"
@@ -29,6 +30,7 @@ androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-toolin
 coil-compose = { module = "io.coil-kt.coil3:coil-compose", version.ref = "coil" }
 coil-compose-core = { module = "io.coil-kt.coil3:coil-compose-core", version.ref = "coil" }
 coil-network = { module = "io.coil-kt.coil3:coil-network-ktor3", version.ref = "coil" }
+google-accompanist = { group = "com.google.accompanist", name = "accompanist-permissions", version.ref = "googleAccompanist" }
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
 ktor-android = { module = "io.ktor:ktor-client-android", version.ref = "ktor" }

--- a/typeform/build.gradle.kts
+++ b/typeform/build.gradle.kts
@@ -39,8 +39,10 @@ kotlin {
                 api(compose.ui)
                 api(compose.uiTooling)
 
+                implementation(libs.androidx.activity.compose)
                 implementation(libs.androidx.navigation.compose)
                 implementation(libs.coil.compose.core)
+                implementation(libs.google.accompanist)
             }
         }
 

--- a/typeform/build.gradle.kts
+++ b/typeform/build.gradle.kts
@@ -42,7 +42,6 @@ kotlin {
                 implementation(libs.androidx.activity.compose)
                 implementation(libs.androidx.navigation.compose)
                 implementation(libs.coil.compose.core)
-                implementation(libs.google.accompanist)
             }
         }
 

--- a/typeform/src/androidMain/kotlin/com/typeform/ui/components/UploadImageView.kt
+++ b/typeform/src/androidMain/kotlin/com/typeform/ui/components/UploadImageView.kt
@@ -68,7 +68,9 @@ fun UploadImageView(
                 Image(
                     bitmap = bitmap!!.asImageBitmap(),
                     contentDescription = null,
-                    modifier = Modifier.fillMaxSize(),
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(padding),
                     alignment = Alignment.Center,
                     contentScale = ContentScale.Fit,
                 )

--- a/typeform/src/androidMain/kotlin/com/typeform/ui/components/UploadImageView.kt
+++ b/typeform/src/androidMain/kotlin/com/typeform/ui/components/UploadImageView.kt
@@ -1,0 +1,154 @@
+package com.typeform.ui.components
+
+import android.graphics.Bitmap
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.sizeIn
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.LocalMinimumInteractiveComponentEnforcement
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.FilePresent
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+import com.typeform.models.Upload
+import com.typeform.ui.models.Settings
+import com.typeform.ui.models.UploadHelper
+import com.typeform.ui.preview.ThemePreview
+
+@OptIn(ExperimentalMaterialApi::class)
+@Composable
+fun UploadImageView(
+    upload: Upload,
+    settings: Settings,
+    uploadHelper: UploadHelper? = null,
+    removeAction: () -> Unit,
+) {
+    val context = LocalContext.current
+    val padding = PaddingValues(8.dp)
+    var bitmap: Bitmap? by remember { mutableStateOf(null) }
+
+    LaunchedEffect(Unit) {
+        bitmap = uploadHelper?.bitmapForUpload(upload, context)?.getOrNull()
+    }
+
+    Column(
+        horizontalAlignment = Alignment.Start,
+    ) {
+        Box(
+            modifier = Modifier.sizeIn(maxWidth = settings.upload.maxWidth ?: Dp.Unspecified),
+            contentAlignment = Alignment.TopEnd,
+        ) {
+            if (bitmap != null) {
+                Image(
+                    bitmap = bitmap!!.asImageBitmap(),
+                    contentDescription = null,
+                    modifier = Modifier.fillMaxSize(),
+                    alignment = Alignment.Center,
+                    contentScale = ContentScale.Fit,
+                )
+            } else {
+                UploadPlaceholderView(
+                    settings = settings,
+                    padding = padding,
+                )
+            }
+
+            CompositionLocalProvider(LocalMinimumInteractiveComponentEnforcement.provides(false)) {
+                IconButton(
+                    onClick = {
+                        removeAction()
+                    },
+                    modifier = Modifier
+                        .background(
+                            color = settings.upload.colors.backgroundColor(true).value,
+                            shape = CircleShape,
+                        ),
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Close,
+                        contentDescription = null,
+                        tint = settings.upload.colors.contentColor(true).value,
+                    )
+                }
+            }
+        }
+
+        StyledTextView(
+            text = upload.fileName,
+            textStyle = MaterialTheme.typography.caption,
+            modifier = Modifier.padding(start = padding.calculateLeftPadding(LayoutDirection.Ltr)),
+        )
+    }
+}
+
+@Composable
+fun UploadPlaceholderView(
+    settings: Settings,
+    padding: PaddingValues,
+) {
+    val glyphWidth: Dp = if (settings.upload.maxWidth != null) {
+        settings.upload.maxWidth.times(0.3f)
+    } else {
+        60.dp
+    }
+
+    Box(
+        modifier = Modifier
+            .aspectRatio(1.0f)
+            .padding(padding)
+            .background(
+                color = settings.upload.colors.backgroundColor(true).value,
+                shape = settings.upload.shape,
+            ),
+        contentAlignment = Alignment.Center,
+    ) {
+        Icon(
+            imageVector = Icons.Default.FilePresent,
+            contentDescription = Icons.Default.FilePresent.name,
+            modifier = Modifier.size(glyphWidth),
+            tint = settings.upload.colors.contentColor(true).value,
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun UploadImageViewPreview() {
+    ThemePreview {
+        UploadImageView(
+            upload = Upload(
+                bytes = byteArrayOf(),
+                path = Upload.Path.CAMERA,
+                mimeType = "image/jpeg",
+                fileName = "IMG_1234567890.jpg",
+            ),
+            settings = Settings(),
+        ) { }
+    }
+}

--- a/typeform/src/androidMain/kotlin/com/typeform/ui/components/UploadPickerView.kt
+++ b/typeform/src/androidMain/kotlin/com/typeform/ui/components/UploadPickerView.kt
@@ -1,51 +1,36 @@
 package com.typeform.ui.components
 
-import android.Manifest
-import android.content.Context
-import android.graphics.Bitmap
-import android.graphics.BitmapFactory
 import android.net.Uri
-import android.provider.OpenableColumns
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.Row
+import androidx.compose.material.DropdownMenuItem
+import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CameraAlt
 import androidx.compose.material.icons.filled.FileUpload
 import androidx.compose.material.icons.filled.PhotoLibrary
-import androidx.compose.material3.DropdownMenuItem
-import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalContext
-import androidx.core.content.FileProvider
-import androidx.core.database.getStringOrNull
-import com.google.accompanist.permissions.ExperimentalPermissionsApi
-import com.google.accompanist.permissions.PermissionStatus
-import com.google.accompanist.permissions.rememberPermissionState
 import com.typeform.models.Upload
 import com.typeform.ui.models.Settings
-import java.io.ByteArrayInputStream
-import java.io.ByteArrayOutputStream
-import java.io.File
-import kotlin.uuid.ExperimentalUuidApi
-import kotlin.uuid.Uuid
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.withContext
+import com.typeform.ui.models.UploadHelper
+import com.typeform.ui.models.constructDocument
+import com.typeform.ui.models.constructImage
 
-@OptIn(ExperimentalPermissionsApi::class, ExperimentalUuidApi::class)
 @Composable
 internal fun UploadPickerView(
     settings: Settings,
-    resultHandler: (Result<Upload>?) -> Unit
+    uploadHelper: UploadHelper? = null,
+    resultHandler: (Result<Upload>?) -> Unit,
 ) {
     val context = LocalContext.current
-    val cameraPermissionState = rememberPermissionState(permission = Manifest.permission.CAMERA)
     var photoUri: Uri? by remember { mutableStateOf(null) }
 
     val cameraLauncher = rememberLauncherForActivityResult(
@@ -55,12 +40,16 @@ internal fun UploadPickerView(
             if (photoUri == null) {
                 resultHandler(null)
             } else {
-                val upload = Upload.constructImage(
-                    uri = photoUri!!,
-                    path = Upload.Path.CAMERA,
-                    context = context
-                )
-                resultHandler(upload)
+                if (uploadHelper != null) {
+                    val upload = uploadHelper.constructImage(
+                        uri = photoUri!!,
+                        path = Upload.Path.CAMERA,
+                        context = context,
+                    )
+                    resultHandler(upload)
+                } else {
+                    resultHandler(null)
+                }
             }
         } else {
             resultHandler(null)
@@ -73,12 +62,16 @@ internal fun UploadPickerView(
         if (uri == null) {
             resultHandler(null)
         } else {
-            val upload = Upload.constructImage(
-                uri = uri,
-                path = Upload.Path.PHOTO_LIBRARY,
-                context = context
-            )
-            resultHandler(upload)
+            if (uploadHelper != null) {
+                val upload = uploadHelper.constructImage(
+                    uri = uri,
+                    path = Upload.Path.PHOTO_LIBRARY,
+                    context = context,
+                )
+                resultHandler(upload)
+            } else {
+                resultHandler(null)
+            }
         }
     }
 
@@ -88,167 +81,83 @@ internal fun UploadPickerView(
         if (uri == null) {
             resultHandler(null)
         } else {
-            val upload = Upload.constructDocument(uri, context)
-            resultHandler(upload)
+            if (uploadHelper != null) {
+                val upload = uploadHelper.constructDocument(uri, context)
+                resultHandler(upload)
+            } else {
+                resultHandler(null)
+            }
         }
     }
 
     fun takePhoto() {
-        when (cameraPermissionState.status) {
-            is PermissionStatus.Denied -> {
-                if ((cameraPermissionState.status as PermissionStatus.Denied).shouldShowRationale) {
-                    resultHandler(Result.failure(Exception("Camera Permission Denied")))
-                } else {
-                    cameraPermissionState.launchPermissionRequest()
+        if (uploadHelper != null) {
+            try {
+                val result = uploadHelper.uriForCameraImage(context)
+                val uri = result.getOrThrow()
+                photoUri = uri
+                uri?.let {
+                    cameraLauncher.launch(it)
                 }
-            }
-            is PermissionStatus.Granted -> {
-                try {
-                    val path = Uuid.random().toString().plus(".jpg")
-                    val file = File(context.cacheDir, path)
-                    val uri = FileProvider.getUriForFile(context, context.packageName, file)
-                    photoUri = uri
-                    cameraLauncher.launch(uri)
-                } catch (exception: Exception) {
-                    resultHandler(Result.failure(exception))
-                }
+            } catch (exception: Exception) {
+                resultHandler(Result.failure(exception))
             }
         }
     }
 
     DropdownMenuItem(
-        text = {
-            StyledTextView(
-                text = settings.localization.uploadCamera,
-                textStyle = MaterialTheme.typography.body1,
-            )
-        },
         onClick = {
             takePhoto()
         },
-        leadingIcon = {
+        enabled = uploadHelper != null,
+    ) {
+        Row {
             Icon(
                 imageVector = Icons.Default.CameraAlt,
                 contentDescription = Icons.Default.CameraAlt.name,
             )
-        }
-    )
 
-    DropdownMenuItem(
-        text = {
             StyledTextView(
-                text = settings.localization.uploadPhotoLibrary,
+                text = settings.localization.uploadCamera,
                 textStyle = MaterialTheme.typography.body1,
             )
-        },
+        }
+    }
+
+    DropdownMenuItem(
         onClick = {
             photoLibraryLauncher.launch(PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly))
         },
-        leadingIcon = {
+    ) {
+        Row {
             Icon(
                 imageVector = Icons.Default.PhotoLibrary,
                 contentDescription = Icons.Default.PhotoLibrary.name,
             )
-        }
-    )
 
-    DropdownMenuItem(
-        text = {
             StyledTextView(
-                text = settings.localization.uploadDocument,
+                text = settings.localization.uploadPhotoLibrary,
                 textStyle = MaterialTheme.typography.body1,
             )
-        },
+        }
+    }
+
+    DropdownMenuItem(
         onClick = {
-            documentsLauncher.launch(listOf(
-                "image/jpeg",
-                "image/png",
-                "application/pdf",
-            ).toTypedArray())
+            documentsLauncher.launch(uploadHelper?.allowedDocumentTypes ?: emptyArray())
         },
-        leadingIcon = {
+        enabled = uploadHelper != null,
+    ) {
+        Row {
             Icon(
                 imageVector = Icons.Default.FileUpload,
                 contentDescription = Icons.Default.FileUpload.name,
             )
+
+            StyledTextView(
+                text = settings.localization.uploadDocument,
+                textStyle = MaterialTheme.typography.body1,
+            )
         }
-    )
-}
-
-fun Upload.Companion.constructImage(
-    uri: Uri,
-    path: Upload.Path,
-    context: Context,
-): Result<Upload> {
-    val contentResolver = context.contentResolver
-
-    var bytes = runBlocking {
-        withContext(Dispatchers.IO) {
-            contentResolver.openInputStream(uri).use {
-                it?.readBytes()
-            }
-        }
-    } ?: return Result.failure(Exception("Could not read file."))
-
-    val inputStream = ByteArrayInputStream(bytes)
-    val bitmap = BitmapFactory.decodeStream(inputStream) ?: return Result.failure(Exception("Could not read bitmap."))
-    val outputStream = ByteArrayOutputStream()
-    bitmap.compress(Bitmap.CompressFormat.JPEG, 90, outputStream)
-    val uploadBytes = outputStream.toByteArray()
-
-    val upload = Upload(
-        bytes = uploadBytes,
-        path = path,
-        mimeType = "image/jpeg",
-        fileName = uri.path ?: "New Image.jpg"
-    )
-
-    return Result.success(upload)
-}
-
-fun Upload.Companion.constructDocument(
-    uri: Uri,
-    context: Context,
-): Result<Upload> {
-    val contentResolver = context.contentResolver
-
-    val contentType = contentResolver.getType(uri)
-        ?: return Result.failure(Exception("Could not read content type."))
-
-    if (contentType != "application/pdf") {
-        return constructImage(uri, Upload.Path.DOCUMENTS, context)
     }
-
-    val query = contentResolver.query(
-        uri,
-        arrayOf(OpenableColumns.DISPLAY_NAME, OpenableColumns.SIZE),
-        null,
-        null,
-    )
-
-    if (query == null) {
-        return Result.failure(Exception("Could not read file name."))
-    }
-
-    val fileName = query.use { cursor ->
-        cursor.moveToFirst()
-        cursor.getStringOrNull(cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)) ?: "New Document"
-    }
-
-    var bytes = runBlocking {
-        withContext(Dispatchers.IO) {
-            contentResolver.openInputStream(uri).use {
-                it?.readBytes()
-            }
-        }
-    } ?: return Result.failure(Exception("Could not read file."))
-
-    val upload = Upload(
-        bytes = bytes,
-        path = Upload.Path.DOCUMENTS,
-        mimeType = contentType,
-        fileName = fileName,
-    )
-
-    return Result.success(upload)
 }

--- a/typeform/src/androidMain/kotlin/com/typeform/ui/components/UploadPickerView.kt
+++ b/typeform/src/androidMain/kotlin/com/typeform/ui/components/UploadPickerView.kt
@@ -1,0 +1,254 @@
+package com.typeform.ui.components
+
+import android.Manifest
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.net.Uri
+import android.provider.OpenableColumns
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.PickVisualMediaRequest
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CameraAlt
+import androidx.compose.material.icons.filled.FileUpload
+import androidx.compose.material.icons.filled.PhotoLibrary
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalContext
+import androidx.core.content.FileProvider
+import androidx.core.database.getStringOrNull
+import com.google.accompanist.permissions.ExperimentalPermissionsApi
+import com.google.accompanist.permissions.PermissionStatus
+import com.google.accompanist.permissions.rememberPermissionState
+import com.typeform.models.Upload
+import com.typeform.ui.models.Settings
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.File
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
+
+@OptIn(ExperimentalPermissionsApi::class, ExperimentalUuidApi::class)
+@Composable
+internal fun UploadPickerView(
+    settings: Settings,
+    resultHandler: (Result<Upload>?) -> Unit
+) {
+    val context = LocalContext.current
+    val cameraPermissionState = rememberPermissionState(permission = Manifest.permission.CAMERA)
+    var photoUri: Uri? by remember { mutableStateOf(null) }
+
+    val cameraLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.TakePicture(),
+    ) { success ->
+        if (success) {
+            if (photoUri == null) {
+                resultHandler(null)
+            } else {
+                val upload = Upload.constructImage(
+                    uri = photoUri!!,
+                    path = Upload.Path.CAMERA,
+                    context = context
+                )
+                resultHandler(upload)
+            }
+        } else {
+            resultHandler(null)
+        }
+    }
+
+    val photoLibraryLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.PickVisualMedia(),
+    ) { uri ->
+        if (uri == null) {
+            resultHandler(null)
+        } else {
+            val upload = Upload.constructImage(
+                uri = uri,
+                path = Upload.Path.PHOTO_LIBRARY,
+                context = context
+            )
+            resultHandler(upload)
+        }
+    }
+
+    val documentsLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.OpenDocument(),
+    ) { uri ->
+        if (uri == null) {
+            resultHandler(null)
+        } else {
+            val upload = Upload.constructDocument(uri, context)
+            resultHandler(upload)
+        }
+    }
+
+    fun takePhoto() {
+        when (cameraPermissionState.status) {
+            is PermissionStatus.Denied -> {
+                if ((cameraPermissionState.status as PermissionStatus.Denied).shouldShowRationale) {
+                    resultHandler(Result.failure(Exception("Camera Permission Denied")))
+                } else {
+                    cameraPermissionState.launchPermissionRequest()
+                }
+            }
+            is PermissionStatus.Granted -> {
+                try {
+                    val path = Uuid.random().toString().plus(".jpg")
+                    val file = File(context.cacheDir, path)
+                    val uri = FileProvider.getUriForFile(context, context.packageName, file)
+                    photoUri = uri
+                    cameraLauncher.launch(uri)
+                } catch (exception: Exception) {
+                    resultHandler(Result.failure(exception))
+                }
+            }
+        }
+    }
+
+    DropdownMenuItem(
+        text = {
+            StyledTextView(
+                text = settings.localization.uploadCamera,
+                textStyle = MaterialTheme.typography.body1,
+            )
+        },
+        onClick = {
+            takePhoto()
+        },
+        leadingIcon = {
+            Icon(
+                imageVector = Icons.Default.CameraAlt,
+                contentDescription = Icons.Default.CameraAlt.name,
+            )
+        }
+    )
+
+    DropdownMenuItem(
+        text = {
+            StyledTextView(
+                text = settings.localization.uploadPhotoLibrary,
+                textStyle = MaterialTheme.typography.body1,
+            )
+        },
+        onClick = {
+            photoLibraryLauncher.launch(PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly))
+        },
+        leadingIcon = {
+            Icon(
+                imageVector = Icons.Default.PhotoLibrary,
+                contentDescription = Icons.Default.PhotoLibrary.name,
+            )
+        }
+    )
+
+    DropdownMenuItem(
+        text = {
+            StyledTextView(
+                text = settings.localization.uploadDocument,
+                textStyle = MaterialTheme.typography.body1,
+            )
+        },
+        onClick = {
+            documentsLauncher.launch(listOf(
+                "image/jpeg",
+                "image/png",
+                "application/pdf",
+            ).toTypedArray())
+        },
+        leadingIcon = {
+            Icon(
+                imageVector = Icons.Default.FileUpload,
+                contentDescription = Icons.Default.FileUpload.name,
+            )
+        }
+    )
+}
+
+fun Upload.Companion.constructImage(
+    uri: Uri,
+    path: Upload.Path,
+    context: Context,
+): Result<Upload> {
+    val contentResolver = context.contentResolver
+
+    var bytes = runBlocking {
+        withContext(Dispatchers.IO) {
+            contentResolver.openInputStream(uri).use {
+                it?.readBytes()
+            }
+        }
+    } ?: return Result.failure(Exception("Could not read file."))
+
+    val inputStream = ByteArrayInputStream(bytes)
+    val bitmap = BitmapFactory.decodeStream(inputStream) ?: return Result.failure(Exception("Could not read bitmap."))
+    val outputStream = ByteArrayOutputStream()
+    bitmap.compress(Bitmap.CompressFormat.JPEG, 90, outputStream)
+    val uploadBytes = outputStream.toByteArray()
+
+    val upload = Upload(
+        bytes = uploadBytes,
+        path = path,
+        mimeType = "image/jpeg",
+        fileName = uri.path ?: "New Image.jpg"
+    )
+
+    return Result.success(upload)
+}
+
+fun Upload.Companion.constructDocument(
+    uri: Uri,
+    context: Context,
+): Result<Upload> {
+    val contentResolver = context.contentResolver
+
+    val contentType = contentResolver.getType(uri)
+        ?: return Result.failure(Exception("Could not read content type."))
+
+    if (contentType != "application/pdf") {
+        return constructImage(uri, Upload.Path.DOCUMENTS, context)
+    }
+
+    val query = contentResolver.query(
+        uri,
+        arrayOf(OpenableColumns.DISPLAY_NAME, OpenableColumns.SIZE),
+        null,
+        null,
+    )
+
+    if (query == null) {
+        return Result.failure(Exception("Could not read file name."))
+    }
+
+    val fileName = query.use { cursor ->
+        cursor.moveToFirst()
+        cursor.getStringOrNull(cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)) ?: "New Document"
+    }
+
+    var bytes = runBlocking {
+        withContext(Dispatchers.IO) {
+            contentResolver.openInputStream(uri).use {
+                it?.readBytes()
+            }
+        }
+    } ?: return Result.failure(Exception("Could not read file."))
+
+    val upload = Upload(
+        bytes = bytes,
+        path = Upload.Path.DOCUMENTS,
+        mimeType = contentType,
+        fileName = fileName,
+    )
+
+    return Result.success(upload)
+}

--- a/typeform/src/androidMain/kotlin/com/typeform/ui/fields/DropdownView.kt
+++ b/typeform/src/androidMain/kotlin/com/typeform/ui/fields/DropdownView.kt
@@ -176,6 +176,7 @@ private fun DropdownViewPreview() {
         settings = Settings(),
         properties = Dropdown(
             choices = emptyList(),
+            description = null,
             randomize = false,
             alphabetical_order = false,
         ),

--- a/typeform/src/androidMain/kotlin/com/typeform/ui/fields/FileUploadView.kt
+++ b/typeform/src/androidMain/kotlin/com/typeform/ui/fields/FileUploadView.kt
@@ -1,0 +1,110 @@
+package com.typeform.ui.fields
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.Button
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.typeform.models.Upload
+import com.typeform.schema.FileUpload
+import com.typeform.schema.Validations
+import com.typeform.ui.components.StyledTextView
+import com.typeform.ui.components.UploadPickerView
+import com.typeform.ui.models.ResponseState
+import com.typeform.ui.models.Settings
+import com.typeform.ui.preview.ThemePreview
+
+@Composable
+internal fun FileUploadView(
+    settings: Settings,
+    properties: FileUpload,
+    responseState: ResponseState,
+    validations: Validations?,
+    stateHandler: (ResponseState) -> Unit,
+) {
+    var value: Upload? by remember { mutableStateOf(responseState.response?.asUpload()) }
+    var expanded: Boolean by remember { mutableStateOf(false) }
+    var path: Upload.Path? by remember { mutableStateOf(null) }
+    var exception: Throwable? by remember { mutableStateOf(null) }
+
+    fun updateState() {
+    }
+
+    fun selectFile() {
+    }
+
+    LaunchedEffect(Unit) {
+        updateState()
+    }
+
+    Column(
+        verticalArrangement = Arrangement.spacedBy(settings.presentation.contentVerticalSpacing),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Button(
+            onClick = {
+                expanded = true
+            },
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            StyledTextView(
+                text = settings.localization.uploadAction,
+                textStyle = MaterialTheme.typography.body1,
+            )
+        }
+
+        DropdownMenu(
+            expanded = expanded,
+            onDismissRequest = {
+                expanded = false
+            },
+        ) {
+            UploadPickerView(
+                settings = settings,
+            ) { result ->
+                expanded = false
+                result?.fold(
+                    onSuccess = {
+                        value = it
+                    },
+                    onFailure = {
+                        exception = it
+                    }
+                )
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun FileUploadViewPreview() {
+    ThemePreview {
+        Box(
+            modifier = Modifier.size(200.dp),
+        ) {
+            FileUploadView(
+                settings = Settings(),
+                properties = FileUpload(
+                    description = "Select a file."
+                ),
+                responseState = ResponseState(),
+                validations = null,
+            ) {
+            }
+        }
+    }
+}

--- a/typeform/src/androidMain/kotlin/com/typeform/ui/models/Settings.kt
+++ b/typeform/src/androidMain/kotlin/com/typeform/ui/models/Settings.kt
@@ -2,6 +2,7 @@ package com.typeform.ui.models
 
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.ButtonColors
 import androidx.compose.material.CheckboxColors
 import androidx.compose.material.RadioButtonColors
@@ -9,6 +10,7 @@ import androidx.compose.material.SliderColors
 import androidx.compose.material.SwitchColors
 import androidx.compose.material.TextFieldColors
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 
@@ -35,10 +37,12 @@ data class Settings(
     val calendar: Calendar = Calendar(),
     val switch: Switch = Switch(),
     val button: Button = Button(),
+    val outlinedButton: OutlinedButton = OutlinedButton(),
     val checkbox: Checkbox = Checkbox(),
     val radio: Radio = Radio(),
     val rating: Rating = Rating(),
     val opinionScale: OpinionScale = OpinionScale(),
+    val upload: Upload = Upload(),
 ) {
     companion object {
         val defaultUnselectedButtonBorderStroke = BorderStroke(
@@ -120,6 +124,13 @@ data class Settings(
         val contentPadding: PaddingValues = PaddingValues(10.dp),
     )
 
+    data class OutlinedButton(
+        val colors: ButtonColors = TypeformButtonColors.outlinedColors,
+        val shape: Shape = RoundedCornerShape(6.dp),
+        val border: BorderStroke? = defaultSelectedButtonBorderStroke,
+        val contentPadding: PaddingValues = PaddingValues(10.dp),
+    )
+
     data class Checkbox(
         val colors: CheckboxColors = TypeformCheckboxColors(),
     )
@@ -134,5 +145,11 @@ data class Settings(
 
     data class OpinionScale(
         val colors: SliderColors = TypeformSliderColors.opinionScaleColors,
+    )
+
+    data class Upload(
+        val colors: ButtonColors = TypeformButtonColors.uploadColors,
+        val shape: Shape = RoundedCornerShape(16.dp),
+        val maxWidth: Dp? = 200.dp,
     )
 }

--- a/typeform/src/androidMain/kotlin/com/typeform/ui/models/Settings.kt
+++ b/typeform/src/androidMain/kotlin/com/typeform/ui/models/Settings.kt
@@ -64,6 +64,10 @@ data class Settings(
         val abandonConfirmationAction: String = "Abandon",
         val emptyChoice: String = "Select an Option",
         val nullDate: String = "I'm not sure…",
+        val uploadAction: String = "Select File",
+        val uploadCamera: String = "Camera",
+        val uploadPhotoLibrary: String = "Photo Library",
+        val uploadDocument: String = "Documents",
     )
 
     data class Presentation(

--- a/typeform/src/androidMain/kotlin/com/typeform/ui/models/TypeformButtonColors.kt
+++ b/typeform/src/androidMain/kotlin/com/typeform/ui/models/TypeformButtonColors.kt
@@ -16,6 +16,13 @@ data class TypeformButtonColors(
     companion object {
         val defaultColors: TypeformButtonColors = TypeformButtonColors()
 
+        val outlinedColors: TypeformButtonColors = TypeformButtonColors()
+
+        val uploadColors: TypeformButtonColors = TypeformButtonColors(
+            backgroundColor = Color.Blue,
+            contentColor = Color.White,
+        )
+
         val ratingColors: TypeformButtonColors = TypeformButtonColors(
             backgroundColor = Color.Black,
             contentColor = Color.Blue,

--- a/typeform/src/androidMain/kotlin/com/typeform/ui/models/UploadHelper.kt
+++ b/typeform/src/androidMain/kotlin/com/typeform/ui/models/UploadHelper.kt
@@ -60,7 +60,7 @@ fun UploadHelper.constructImage(
         bytes = uploadBytes,
         path = path,
         mimeType = "image/jpeg",
-        fileName = uri.path ?: "New Image.jpg",
+        fileName = uri.lastPathSegment ?: "New Image.jpg",
     )
 
     return Result.success(upload)

--- a/typeform/src/androidMain/kotlin/com/typeform/ui/models/UploadHelper.kt
+++ b/typeform/src/androidMain/kotlin/com/typeform/ui/models/UploadHelper.kt
@@ -1,0 +1,114 @@
+package com.typeform.ui.models
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.net.Uri
+import android.provider.OpenableColumns
+import androidx.core.database.getStringOrNull
+import com.typeform.models.Upload
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
+
+interface UploadHelper {
+    /**
+     * Collection of MIME types that are allowed to be selected for document uploads.
+     */
+    val allowedDocumentTypes: Array<String>
+
+    /**
+     * Provide a [Uri] that can be written to by the device hardware camera.
+     *
+     * Each device is required to handle hardware permissions as needed.
+     */
+    fun uriForCameraImage(context: Context): Result<Uri?>
+
+    /**
+     * Generate a preview/thumbnail [Bitmap] for the provided [Upload].
+     */
+    fun bitmapForUpload(
+        upload: Upload,
+        context: Context,
+    ): Result<Bitmap>
+}
+
+fun UploadHelper.constructImage(
+    uri: Uri,
+    path: Upload.Path,
+    context: Context,
+): Result<Upload> {
+    val contentResolver = context.contentResolver
+
+    var bytes = runBlocking {
+        withContext(Dispatchers.IO) {
+            contentResolver.openInputStream(uri).use {
+                it?.readBytes()
+            }
+        }
+    } ?: return Result.failure(Exception("Could not read file."))
+
+    val inputStream = ByteArrayInputStream(bytes)
+    val bitmap = BitmapFactory.decodeStream(inputStream) ?: return Result.failure(Exception("Could not read bitmap."))
+    val outputStream = ByteArrayOutputStream()
+    bitmap.compress(Bitmap.CompressFormat.JPEG, 90, outputStream)
+    val uploadBytes = outputStream.toByteArray()
+
+    val upload = Upload(
+        bytes = uploadBytes,
+        path = path,
+        mimeType = "image/jpeg",
+        fileName = uri.path ?: "New Image.jpg",
+    )
+
+    return Result.success(upload)
+}
+
+fun UploadHelper.constructDocument(
+    uri: Uri,
+    context: Context,
+): Result<Upload> {
+    val contentResolver = context.contentResolver
+
+    val contentType = contentResolver.getType(uri)
+        ?: return Result.failure(Exception("Could not read content type."))
+
+    if (contentType != "application/pdf") {
+        return constructImage(uri, Upload.Path.DOCUMENTS, context)
+    }
+
+    val query = contentResolver.query(
+        uri,
+        arrayOf(OpenableColumns.DISPLAY_NAME, OpenableColumns.SIZE),
+        null,
+        null,
+    )
+
+    if (query == null) {
+        return Result.failure(Exception("Could not read file name."))
+    }
+
+    val fileName = query.use { cursor ->
+        cursor.moveToFirst()
+        cursor.getStringOrNull(cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)) ?: "New Document"
+    }
+
+    var bytes = runBlocking {
+        withContext(Dispatchers.IO) {
+            contentResolver.openInputStream(uri).use {
+                it?.readBytes()
+            }
+        }
+    } ?: return Result.failure(Exception("Could not read file."))
+
+    val upload = Upload(
+        bytes = bytes,
+        path = Upload.Path.DOCUMENTS,
+        mimeType = contentType,
+        fileName = fileName,
+    )
+
+    return Result.success(upload)
+}

--- a/typeform/src/androidMain/kotlin/com/typeform/ui/preview/FieldPreview.kt
+++ b/typeform/src/androidMain/kotlin/com/typeform/ui/preview/FieldPreview.kt
@@ -40,6 +40,7 @@ val Field.Companion.previewDropdown: Field
                     Choice.previewHot,
                     Choice.previewCold,
                 ),
+                description = null,
                 randomize = false,
                 alphabetical_order = false,
             ),

--- a/typeform/src/androidMain/kotlin/com/typeform/ui/structure/FieldView.kt
+++ b/typeform/src/androidMain/kotlin/com/typeform/ui/structure/FieldView.kt
@@ -45,6 +45,7 @@ import com.typeform.ui.models.Conclusion
 import com.typeform.ui.models.NavigationAction
 import com.typeform.ui.models.ResponseState
 import com.typeform.ui.models.Settings
+import com.typeform.ui.models.UploadHelper
 import com.typeform.ui.preview.ThemePreview
 import com.typeform.ui.preview.preview
 import com.typeform.ui.preview.previewDate
@@ -63,6 +64,7 @@ internal fun FieldView(
     group: Group?,
     responses: Responses,
     imageLoader: ImageLoader? = null,
+    uploadHelper: UploadHelper? = null,
     header: (@Composable () -> Unit)? = null,
     actionHandler: (NavigationAction) -> Unit,
 ) {
@@ -193,6 +195,7 @@ internal fun FieldView(
                             properties = field.properties.properties,
                             responseState = responseState,
                             validations = field.validations,
+                            uploadHelper = uploadHelper,
                         ) {
                             handleResponseState(it)
                         }

--- a/typeform/src/androidMain/kotlin/com/typeform/ui/structure/FieldView.kt
+++ b/typeform/src/androidMain/kotlin/com/typeform/ui/structure/FieldView.kt
@@ -33,6 +33,7 @@ import com.typeform.schema.ThankYouScreen
 import com.typeform.ui.components.StyledTextView
 import com.typeform.ui.fields.DateView
 import com.typeform.ui.fields.DropdownView
+import com.typeform.ui.fields.FileUploadView
 import com.typeform.ui.fields.LongTextView
 import com.typeform.ui.fields.MultipleChoiceView
 import com.typeform.ui.fields.NumberView
@@ -178,6 +179,16 @@ internal fun FieldView(
                     }
                     is FieldProperties.DropdownProperties -> {
                         DropdownView(
+                            settings = settings,
+                            properties = field.properties.properties,
+                            responseState = responseState,
+                            validations = field.validations,
+                        ) {
+                            handleResponseState(it)
+                        }
+                    }
+                    is FieldProperties.FileUploadProperties -> {
+                        FileUploadView(
                             settings = settings,
                             properties = field.properties.properties,
                             responseState = responseState,

--- a/typeform/src/androidMain/kotlin/com/typeform/ui/structure/FormView.kt
+++ b/typeform/src/androidMain/kotlin/com/typeform/ui/structure/FormView.kt
@@ -44,6 +44,7 @@ import com.typeform.ui.components.StyledTextView
 import com.typeform.ui.models.Conclusion
 import com.typeform.ui.models.NavigationAction
 import com.typeform.ui.models.Settings
+import com.typeform.ui.models.UploadHelper
 import com.typeform.ui.preview.ThemePreview
 import com.typeform.ui.preview.preview
 
@@ -56,6 +57,7 @@ fun FormView(
     settings: Settings = Settings(),
     responses: Responses = mutableMapOf(),
     imageLoader: ImageLoader? = null,
+    uploadHelper: UploadHelper? = null,
     conclusion: (Conclusion) -> Unit,
     header: (@Composable () -> Unit)? = null,
 ) {
@@ -262,6 +264,7 @@ fun FormView(
                     group = group,
                     responses = responses,
                     imageLoader = imageLoader,
+                    uploadHelper = uploadHelper,
                     header = header,
                     actionHandler = { navigationAction ->
                         navigateUsing(navigationAction)

--- a/typeform/src/androidUnitTest/resources/DemoForm.json
+++ b/typeform/src/androidUnitTest/resources/DemoForm.json
@@ -1,1027 +1,1076 @@
 {
-  "id": "hu2FodCY",
-  "type": "quiz",
-  "title": "Demo Form 2025-01-15",
-  "workspace": {
-    "href": "https://api.typeform.com/workspaces/5PY2Nu"
-  },
-  "theme": {
-    "href": "https://api.typeform.com/themes/qHWOQ7"
-  },
-  "settings": {
-    "language": "en",
-    "progress_bar": "proportion",
-    "meta": {
-      "allow_indexing": false
+    "id": "hu2FodCY",
+    "type": "quiz",
+    "title": "All Question Types Demo Form",
+    "workspace": {
+        "href": "https://api.typeform.com/workspaces/5PY2Nu"
     },
-    "hide_navigation": false,
-    "is_public": true,
-    "is_trial": false,
-    "show_progress_bar": true,
-    "show_typeform_branding": true,
-    "are_uploads_public": false,
-    "show_time_to_complete": true,
-    "show_number_of_submissions": false,
-    "show_cookie_consent": false,
-    "show_question_number": true,
-    "show_key_hint_on_choices": true,
-    "autosave_progress": true,
-    "free_form_navigation": false,
-    "use_lead_qualification": false,
-    "pro_subdomain_enabled": false
-  },
-  "thankyou_screens": [
-    {
-      "id": "AAsgeOEBHWAC",
-      "ref": "thank-you-1-typeform",
-      "title": "Thanks for submitting your responses",
-      "type": "thankyou_screen",
-      "properties": {
-        "show_button": false,
-        "share_icons": false,
-        "button_mode": "default_redirect",
-        "button_text": "again",
-        "description": "Thank you"
-      }
+    "theme": {
+        "href": "https://api.typeform.com/themes/qHWOQ7"
     },
-    {
-      "id": "A308ZjazcJQ6",
-      "ref": "thank-you-2-typeform",
-      "title": "Thank you for letting us know.",
-      "type": "thankyou_screen",
-      "properties": {
-        "show_button": false,
-        "share_icons": false,
-        "button_mode": "default_redirect",
-        "button_text": "again",
-        "description": "Thanks again"
-      }
+    "settings": {
+        "language": "en",
+        "progress_bar": "proportion",
+        "meta": {
+            "allow_indexing": false
+        },
+        "hide_navigation": false,
+        "is_public": true,
+        "is_trial": false,
+        "show_progress_bar": true,
+        "show_typeform_branding": true,
+        "are_uploads_public": false,
+        "show_time_to_complete": true,
+        "show_number_of_submissions": false,
+        "show_cookie_consent": false,
+        "show_question_number": true,
+        "show_key_hint_on_choices": true,
+        "autosave_progress": true,
+        "free_form_navigation": false,
+        "use_lead_qualification": false,
+        "pro_subdomain_enabled": false
     },
-    {
-      "id": "DefaultTyScreen",
-      "ref": "default_tys",
-      "title": "Thanks for completing this typeform\nNow *create your own* — it's free, easy, \u0026 beautiful",
-      "type": "thankyou_screen",
-      "properties": {
-        "show_button": true,
-        "share_icons": false,
-        "button_mode": "default_redirect",
-        "button_text": "Create a *typeform*"
-      },
-      "attachment": {
-        "type": "image",
-        "href": "https://images.typeform.com/images/2dpnUBBkz2VN"
-      }
-    }
-  ],
-  "welcome_screens": [
-    {
-      "id": "iVVVXbYhFAqt",
-      "ref": "welcome-1-typeform",
-      "title": "Welcome to Typeform",
-      "properties": {
-        "show_button": true,
-        "button_text": "Start",
-        "description": "Demo Now"
-      }
-    }
-  ],
-  "fields": [
-    {
-      "id": "UKrtkRy8EAY2",
-      "title": "Several Typeform questions will follow",
-      "ref": "question-group-typeform",
-      "properties": {
-        "description": "Answers are appreciated",
-        "button_text": "Continue",
-        "show_button": true,
-        "fields": [
-          {
-            "id": "M6IDI3o5xRXu",
-            "title": "Do you enjoy using Typeform?",
-            "ref": "group-yes-no-typeform",
+    "thankyou_screens": [
+        {
+            "id": "AAsgeOEBHWAC",
+            "ref": "thank-you-1-typeform",
+            "title": "Thanks for submitting your responses",
+            "type": "thankyou_screen",
             "properties": {
-              "description": "Yes/No Question"
+                "show_button": false,
+                "share_icons": false,
+                "button_mode": "default_redirect",
+                "button_text": "again",
+                "description": "Thank you"
+            }
+        },
+        {
+            "id": "A308ZjazcJQ6",
+            "ref": "thank-you-2-typeform",
+            "title": "Thank you for letting us know.",
+            "type": "thankyou_screen",
+            "properties": {
+                "show_button": false,
+                "share_icons": false,
+                "button_mode": "default_redirect",
+                "button_text": "again",
+                "description": "Thanks again"
+            }
+        },
+        {
+            "id": "DefaultTyScreen",
+            "ref": "default_tys",
+            "title": "Thanks for completing this typeform\nNow *create your own* — it's free, easy, \u0026 beautiful",
+            "type": "thankyou_screen",
+            "properties": {
+                "show_button": true,
+                "share_icons": false,
+                "button_mode": "default_redirect",
+                "button_text": "Create a *typeform*"
+            },
+            "attachment": {
+                "type": "image",
+                "href": "https://images.typeform.com/images/2dpnUBBkz2VN"
+            }
+        }
+    ],
+    "welcome_screens": [
+        {
+            "id": "iVVVXbYhFAqt",
+            "ref": "welcome-1-typeform",
+            "title": "Welcome to Typeform",
+            "properties": {
+                "show_button": true,
+                "button_text": "Start",
+                "description": "Demo Now"
+            }
+        }
+    ],
+    "fields": [
+        {
+            "id": "UKrtkRy8EAY2",
+            "title": "Several Typeform questions will follow",
+            "ref": "question-group-typeform",
+            "properties": {
+                "description": "Answers are appreciated",
+                "button_text": "Continue",
+                "show_button": true,
+                "fields": [
+                    {
+                        "id": "M6IDI3o5xRXu",
+                        "title": "Do you enjoy using Typeform?",
+                        "ref": "question-group-yes-no-typeform",
+                        "properties": {
+                            "description": "Yes/No Question"
+                        },
+                        "validations": {
+                            "required": false
+                        },
+                        "type": "yes_no"
+                    },
+                    {
+                        "id": "aUWEtefTVNrl",
+                        "title": "Upload your response",
+                        "ref": "question-group-file-upload-typeform",
+                        "properties": {
+                            "description": "Choose a file"
+                        },
+                        "validations": {
+                            "required": false
+                        },
+                        "type": "file_upload"
+                    }
+                ]
+            },
+            "type": "group",
+            "attachment": {
+                "type": "image",
+                "href": "https://images.typeform.com/images/ehHzhjZQS4FL",
+                "properties": {
+                    "description": "v4-460px-Calculate-Your-Heart-Rate-Step-1-Version-2"
+                }
+            },
+            "layout": {
+                "type": "stack",
+                "attachment": {
+                    "type": "image",
+                    "href": "https://images.typeform.com/images/ehHzhjZQS4FL",
+                    "properties": {
+                        "description": "v4-460px-Calculate-Your-Heart-Rate-Step-1-Version-2"
+                    }
+                },
+                "viewport_overrides": {}
+            }
+        },
+        {
+            "id": "JmxJ5tpY1WQI",
+            "title": "Does Niceform look better than Typeform?",
+            "ref": "yes-no-typeform",
+            "properties": {
+                "description": "This is Niceform"
             },
             "validations": {
-              "required": false
+                "required": true
             },
             "type": "yes_no"
-          }
-        ]
-      },
-      "type": "group"
-    },
-    {
-      "id": "7BP0MLinDRSK",
-      "title": "We're sorry to hear that you aren't enjoying Typeform.",
-      "ref": "statement-typeform",
-      "properties": {
-        "description": "Let us know how we can do better!",
-        "button_text": "Okay",
-        "hide_marks": true
-      },
-      "type": "statement"
-    },
-    {
-      "id": "JmxJ5tpY1WQI",
-      "title": "Does Niceform look better than Typeform?",
-      "ref": "yes-no-typeform",
-      "properties": {
-        "description": "This is Niceform"
-      },
-      "validations": {
-        "required": true
-      },
-      "type": "yes_no"
-    },
-    {
-      "id": "t5R9fs0sl5mo",
-      "title": "How many times have you used Typeform?",
-      "ref": "number-typeform",
-      "properties": {
-        "description": "Number Input without min or max values"
-      },
-      "validations": {
-        "required": false
-      },
-      "type": "number"
-    },
-    {
-      "id": "n3hxAXv29P9b",
-      "title": "Pick a number between 1 and 100",
-      "ref": "number-min-max-typeform",
-      "properties": {
-        "description": "Number Input with min value of 1 and max value of 100"
-      },
-      "validations": {
-        "required": false,
-        "min_value": 1,
-        "max_value": 100
-      },
-      "type": "number"
-    },
-    {
-      "id": "gRxfXcvybjXL",
-      "title": "What was the date of your last Typeform submission?",
-      "ref": "date-typeform",
-      "properties": {
-        "description": "Provide the approximate month, day, and year",
-        "separator": "/",
-        "structure": "MMDDYYYY"
-      },
-      "validations": {
-        "required": false
-      },
-      "type": "date"
-    },
-    {
-      "id": "GD9E3EwWEJ1N",
-      "title": "How would you rate Typeform?",
-      "ref": "opinion-scale-typeform",
-      "properties": {
-        "description": "Required Opinion Scale 0-5 with left, center and right labels",
-        "start_at_one": false,
-        "steps": 6,
-        "labels": {
-          "left": "Left",
-          "center": "Center",
-          "right": "Right"
+        },
+        {
+            "id": "7BP0MLinDRSK",
+            "title": "We're sorry to hear that you aren't enjoying Typeform.",
+            "ref": "statement-typeform",
+            "properties": {
+                "description": "Let us know how we can do better!",
+                "button_text": "Okay",
+                "hide_marks": true
+            },
+            "type": "statement"
+        },
+        {
+            "id": "t5R9fs0sl5mo",
+            "title": "How many times have you used Typeform?",
+            "ref": "number-typeform",
+            "properties": {
+                "description": "Number Input without min or max values"
+            },
+            "validations": {
+                "required": false
+            },
+            "type": "number"
+        },
+        {
+            "id": "n3hxAXv29P9b",
+            "title": "Pick a number between 1 and 100",
+            "ref": "number-min-max-typeform",
+            "properties": {
+                "description": "Number Input with min value of 1 and max value of 100"
+            },
+            "validations": {
+                "required": false,
+                "min_value": 1,
+                "max_value": 100
+            },
+            "type": "number"
+        },
+        {
+            "id": "gRxfXcvybjXL",
+            "title": "What was the date of your last Typeform submission?",
+            "ref": "date-typeform",
+            "properties": {
+                "description": "Provide the approximate month, day, and year",
+                "separator": "/",
+                "structure": "MMDDYYYY"
+            },
+            "validations": {
+                "required": false
+            },
+            "type": "date"
+        },
+        {
+            "id": "GD9E3EwWEJ1N",
+            "title": "How would you rate Typeform?",
+            "ref": "opinion-scale-typeform",
+            "properties": {
+                "description": "Required Opinion Scale 0-5 with left, center and right labels",
+                "start_at_one": false,
+                "steps": 6,
+                "labels": {
+                    "left": "Left",
+                    "center": "Center",
+                    "right": "Right"
+                }
+            },
+            "validations": {
+                "required": true
+            },
+            "type": "opinion_scale"
+        },
+        {
+            "id": "KAKnlynjXK3x",
+            "title": "How would you rate this custom form?",
+            "ref": "opinion-scale-no-labels-typeform",
+            "properties": {
+                "description": "Optional Opinion Scale 1-10 without labels",
+                "start_at_one": true,
+                "steps": 10
+            },
+            "validations": {
+                "required": false
+            },
+            "type": "opinion_scale"
+        },
+        {
+            "id": "PrRVCB9NtZpG",
+            "title": "What is your preferred choice if you can pick only one?",
+            "ref": "single-choice-typeform",
+            "properties": {
+                "description": "Single Choice",
+                "randomize": false,
+                "allow_multiple_selection": false,
+                "allow_other_choice": false,
+                "vertical_alignment": true,
+                "choices": [
+                    {
+                        "id": "d5ArurLWRvs8",
+                        "ref": "sex-assigned-at-birth-answer-male",
+                        "label": "Choice 1"
+                    },
+                    {
+                        "id": "3RTXiBQd5fjU",
+                        "ref": "sex-assigned-at-birth-answer-female",
+                        "label": "Choice 2"
+                    },
+                    {
+                        "id": "ezuojAOeU0SV",
+                        "ref": "e0832847-9553-49d0-b9e4-bb5b56571542",
+                        "label": "Choice 3"
+                    },
+                    {
+                        "id": "3B6F5r8letVK",
+                        "ref": "3164b1b9-ebff-40d3-aa7a-97ec1c429f00",
+                        "label": "Choice 4"
+                    },
+                    {
+                        "id": "j2kt8CVQzk6P",
+                        "ref": "71ff649e-d6da-40f1-b509-45afd5b40f01",
+                        "label": "Choice 5"
+                    },
+                    {
+                        "id": "d7PSkzMnmNJd",
+                        "ref": "93409c27-4268-4eb6-a25b-2b4c49ed8e4e",
+                        "label": "Choice 6"
+                    },
+                    {
+                        "id": "4jYXN8TDDC5g",
+                        "ref": "4b823147-16ed-4e16-a985-7fab5bc079b5",
+                        "label": "Choice 7"
+                    },
+                    {
+                        "id": "prjFE1sivGU2",
+                        "ref": "2cbdc1f5-3f9b-497c-8045-02edd75b1842",
+                        "label": "Choice 8"
+                    },
+                    {
+                        "id": "Atoxcgx7dV1b",
+                        "ref": "a5b4aad6-d59a-45c6-ac69-3da797b69a2f",
+                        "label": "Choice 9"
+                    },
+                    {
+                        "id": "mCBG49qPwnx6",
+                        "ref": "79c2a289-5177-4a42-a358-070235235aad",
+                        "label": "Choice 10"
+                    },
+                    {
+                        "id": "2Pbv5ndecCNQ",
+                        "ref": "3ea3a20e-a8fb-4538-92c3-c899c718de8d",
+                        "label": "Choice 11"
+                    },
+                    {
+                        "id": "s056SYi7qsaC",
+                        "ref": "a2221797-2e9a-4747-b8ca-b93f785f76b7",
+                        "label": "Choice 12"
+                    },
+                    {
+                        "id": "7AhfqPbfPl6T",
+                        "ref": "41eb405d-ef7d-4397-b0bc-6dbebf7a78ff",
+                        "label": "Choice 13"
+                    }
+                ]
+            },
+            "validations": {
+                "required": false
+            },
+            "type": "multiple_choice"
+        },
+        {
+            "id": "trIA73HjP2Ed",
+            "title": "What are your preferred choices if you can pick more than one?",
+            "ref": "multiple-choice-typeform",
+            "properties": {
+                "description": "Multiple Choice",
+                "randomize": true,
+                "allow_multiple_selection": true,
+                "allow_other_choice": true,
+                "vertical_alignment": true,
+                "choices": [
+                    {
+                        "id": "eaU2HUrNK6UI",
+                        "ref": "97a4d38d-152a-4107-a9b9-4dedefe2c352",
+                        "label": "Choice 1"
+                    },
+                    {
+                        "id": "KNuLxFP67DiY",
+                        "ref": "c1b6c214-e859-45d3-9ac7-f364b5dfea67",
+                        "label": "Choice 2"
+                    },
+                    {
+                        "id": "4x7nNsirXzjY",
+                        "ref": "015fa49c-867e-4b70-a49a-e64af11a25b6",
+                        "label": "Choice 3"
+                    },
+                    {
+                        "id": "XHurflYOnxLd",
+                        "ref": "3b6ec34c-ee7d-4eb2-8e73-257fc5b51dae",
+                        "label": "Choice 4"
+                    },
+                    {
+                        "id": "6EGnzXNL3dDH",
+                        "ref": "3c9fb096-9f14-4887-be7b-4089b8b0f183",
+                        "label": "Choice 5"
+                    },
+                    {
+                        "id": "QUoh8CHTuh7m",
+                        "ref": "80c3a505-55c0-4507-b038-d374f8cc2537",
+                        "label": "Choice 6"
+                    },
+                    {
+                        "id": "oH7a0T6ksua4",
+                        "ref": "d3b49df2-03ec-4b80-9df5-66d38412a1c3",
+                        "label": "Choice 7"
+                    },
+                    {
+                        "id": "RZ2i82tgXxGO",
+                        "ref": "35bfea7b-4e21-41da-b6f6-6bbaed82fc78",
+                        "label": "Choice 8"
+                    },
+                    {
+                        "id": "mZQYcl8Pv8ai",
+                        "ref": "fe759efd-a142-4c58-a0ba-4eaf70d0f5c5",
+                        "label": "Choice 9"
+                    },
+                    {
+                        "id": "GDFg8jzmGrh2",
+                        "ref": "f6c4cec6-7586-452a-ae57-daa7bdba74bb",
+                        "label": "Choice 10"
+                    },
+                    {
+                        "id": "AoMvBixavYIU",
+                        "ref": "1e11582d-77d0-4ec0-b702-be3665457e32",
+                        "label": "Choice 11"
+                    },
+                    {
+                        "id": "yJ2h5Aa4hvWA",
+                        "ref": "7a47db41-389b-46cd-923a-c755422c61a7",
+                        "label": "Choice 12"
+                    },
+                    {
+                        "id": "hCNcbMtp6kkg",
+                        "ref": "7337327e-fc76-4740-a6a4-d82a5fbc2081",
+                        "label": "Choice 13"
+                    }
+                ]
+            },
+            "validations": {
+                "required": true,
+                "min_selection": 1,
+                "max_selection": 5
+            },
+            "type": "multiple_choice"
+        },
+        {
+            "id": "o0cye0lMrUcW",
+            "title": "What are your preferred selections if you can pick more than one?",
+            "ref": "select-dropdown-typeform",
+            "properties": {
+                "description": "Select Dropdown",
+                "randomize": false,
+                "alphabetical_order": false,
+                "choices": [
+                    {
+                        "id": "Ug3yOICPvQBU",
+                        "ref": "8427e552-fc77-487a-95f7-0dabdad378c3",
+                        "label": "Choice 1"
+                    },
+                    {
+                        "id": "c3cifMeDkCkg",
+                        "ref": "60d3d3fb-c506-48bb-893f-c49be2ae4564",
+                        "label": "Choice 2"
+                    },
+                    {
+                        "id": "osAGXR5RrTNH",
+                        "ref": "542f48ca-0e13-4b3e-98f2-dc6a733df5ca",
+                        "label": "Choice 3"
+                    },
+                    {
+                        "id": "Z9vVm9N855kI",
+                        "ref": "5ed9cd92-cd39-4f81-a432-51c8e3f1fa03",
+                        "label": "Choice 4"
+                    },
+                    {
+                        "id": "5Q9z0iQMBghE",
+                        "ref": "f429a7ba-1152-4685-b2b6-9d48954ccb5d",
+                        "label": "Choice 5"
+                    },
+                    {
+                        "id": "DG52NBYaHQLu",
+                        "ref": "458b3c14-ff18-4481-9c02-12ab4477e5c1",
+                        "label": "Choice 6"
+                    },
+                    {
+                        "id": "zqyKA5EdZ4zz",
+                        "ref": "27a93fcc-fd91-47c9-98ee-47725480fb20",
+                        "label": "Choice 7"
+                    },
+                    {
+                        "id": "puasbatuPh9P",
+                        "ref": "ae94edeb-f4d4-4dbb-9829-a331e8dacc5c",
+                        "label": "Choice 8"
+                    },
+                    {
+                        "id": "YmlaMim8DvAN",
+                        "ref": "386b0b2a-d9bc-4f2c-a69d-5c7715c0b803",
+                        "label": "Choice 9"
+                    },
+                    {
+                        "id": "yZHBEDZhalxp",
+                        "ref": "c25c9067-37af-43cf-8293-aa316fa7e077",
+                        "label": "Choice 10"
+                    },
+                    {
+                        "id": "yllDa8yH5NWd",
+                        "ref": "9b00e50a-fe8a-4b1d-8226-f9a6d9eee3be",
+                        "label": "Choice 11"
+                    },
+                    {
+                        "id": "mKFD51AMW8Nc",
+                        "ref": "1602e5b9-b1d1-4ad6-a040-fbc2b65f0678",
+                        "label": "Choice 12"
+                    },
+                    {
+                        "id": "ZhevX99Crsng",
+                        "ref": "01789c8f-9ad1-496d-86c8-40639e4bbc14",
+                        "label": "Choice 13"
+                    }
+                ]
+            },
+            "validations": {
+                "required": false
+            },
+            "type": "dropdown"
+        },
+        {
+            "id": "uVd9KWczmiqY",
+            "title": "Please input some short text here",
+            "ref": "short-text-typeform",
+            "properties": {
+                "description": "Short Text Input"
+            },
+            "validations": {
+                "required": false
+            },
+            "type": "short_text"
+        },
+        {
+            "id": "gCx4CXfFPddk",
+            "title": "Please input some long text here",
+            "ref": "long-text-typeform",
+            "properties": {
+                "description": "Long Text Input"
+            },
+            "validations": {
+                "required": false
+            },
+            "type": "long_text"
         }
-      },
-      "validations": {
-        "required": true
-      },
-      "type": "opinion_scale"
-    },
-    {
-      "id": "KAKnlynjXK3x",
-      "title": "How would you rate this custom form?",
-      "ref": "opinion-scale-no-labels-typeform",
-      "properties": {
-        "description": "Optional Opinion Scale 1-10 without labels",
-        "start_at_one": true,
-        "steps": 10
-      },
-      "validations": {
-        "required": false
-      },
-      "type": "opinion_scale"
-    },
-    {
-      "id": "PrRVCB9NtZpG",
-      "title": "What is your preferred choice if you can pick only one?",
-      "ref": "single-choice-typeform",
-      "properties": {
-        "description": "Single Choice",
-        "randomize": false,
-        "allow_multiple_selection": false,
-        "allow_other_choice": false,
-        "vertical_alignment": true,
-        "choices": [
-          {
-            "id": "d5ArurLWRvs8",
-            "ref": "sex-assigned-at-birth-answer-male",
-            "label": "Choice 1"
-          },
-          {
-            "id": "3RTXiBQd5fjU",
-            "ref": "sex-assigned-at-birth-answer-female",
-            "label": "Choice 2"
-          },
-          {
-            "id": "ezuojAOeU0SV",
-            "ref": "e0832847-9553-49d0-b9e4-bb5b56571542",
-            "label": "Choice 3"
-          },
-          {
-            "id": "3B6F5r8letVK",
-            "ref": "3164b1b9-ebff-40d3-aa7a-97ec1c429f00",
-            "label": "Choice 4"
-          },
-          {
-            "id": "j2kt8CVQzk6P",
-            "ref": "71ff649e-d6da-40f1-b509-45afd5b40f01",
-            "label": "Choice 5"
-          },
-          {
-            "id": "d7PSkzMnmNJd",
-            "ref": "93409c27-4268-4eb6-a25b-2b4c49ed8e4e",
-            "label": "Choice 6"
-          },
-          {
-            "id": "4jYXN8TDDC5g",
-            "ref": "4b823147-16ed-4e16-a985-7fab5bc079b5",
-            "label": "Choice 7"
-          },
-          {
-            "id": "prjFE1sivGU2",
-            "ref": "2cbdc1f5-3f9b-497c-8045-02edd75b1842",
-            "label": "Choice 8"
-          },
-          {
-            "id": "Atoxcgx7dV1b",
-            "ref": "a5b4aad6-d59a-45c6-ac69-3da797b69a2f",
-            "label": "Choice 9"
-          },
-          {
-            "id": "mCBG49qPwnx6",
-            "ref": "79c2a289-5177-4a42-a358-070235235aad",
-            "label": "Choice 10"
-          },
-          {
-            "id": "2Pbv5ndecCNQ",
-            "ref": "3ea3a20e-a8fb-4538-92c3-c899c718de8d",
-            "label": "Choice 11"
-          },
-          {
-            "id": "s056SYi7qsaC",
-            "ref": "a2221797-2e9a-4747-b8ca-b93f785f76b7",
-            "label": "Choice 12"
-          },
-          {
-            "id": "7AhfqPbfPl6T",
-            "ref": "41eb405d-ef7d-4397-b0bc-6dbebf7a78ff",
-            "label": "Choice 13"
-          }
-        ]
-      },
-      "validations": {
-        "required": false
-      },
-      "type": "multiple_choice"
-    },
-    {
-      "id": "trIA73HjP2Ed",
-      "title": "What are your preferred choices if you can pick more than one?",
-      "ref": "multiple-choice-typeform",
-      "properties": {
-        "description": "Multiple Choice",
-        "randomize": true,
-        "allow_multiple_selection": true,
-        "allow_other_choice": true,
-        "vertical_alignment": true,
-        "choices": [
-          {
-            "id": "eaU2HUrNK6UI",
-            "ref": "97a4d38d-152a-4107-a9b9-4dedefe2c352",
-            "label": "Choice 1"
-          },
-          {
-            "id": "KNuLxFP67DiY",
-            "ref": "c1b6c214-e859-45d3-9ac7-f364b5dfea67",
-            "label": "Choice 2"
-          },
-          {
-            "id": "4x7nNsirXzjY",
-            "ref": "015fa49c-867e-4b70-a49a-e64af11a25b6",
-            "label": "Choice 3"
-          },
-          {
-            "id": "XHurflYOnxLd",
-            "ref": "3b6ec34c-ee7d-4eb2-8e73-257fc5b51dae",
-            "label": "Choice 4"
-          },
-          {
-            "id": "6EGnzXNL3dDH",
-            "ref": "3c9fb096-9f14-4887-be7b-4089b8b0f183",
-            "label": "Choice 5"
-          },
-          {
-            "id": "QUoh8CHTuh7m",
-            "ref": "80c3a505-55c0-4507-b038-d374f8cc2537",
-            "label": "Choice 6"
-          },
-          {
-            "id": "oH7a0T6ksua4",
-            "ref": "d3b49df2-03ec-4b80-9df5-66d38412a1c3",
-            "label": "Choice 7"
-          },
-          {
-            "id": "RZ2i82tgXxGO",
-            "ref": "35bfea7b-4e21-41da-b6f6-6bbaed82fc78",
-            "label": "Choice 8"
-          },
-          {
-            "id": "mZQYcl8Pv8ai",
-            "ref": "fe759efd-a142-4c58-a0ba-4eaf70d0f5c5",
-            "label": "Choice 9"
-          },
-          {
-            "id": "GDFg8jzmGrh2",
-            "ref": "f6c4cec6-7586-452a-ae57-daa7bdba74bb",
-            "label": "Choice 10"
-          },
-          {
-            "id": "AoMvBixavYIU",
-            "ref": "1e11582d-77d0-4ec0-b702-be3665457e32",
-            "label": "Choice 11"
-          },
-          {
-            "id": "yJ2h5Aa4hvWA",
-            "ref": "7a47db41-389b-46cd-923a-c755422c61a7",
-            "label": "Choice 12"
-          },
-          {
-            "id": "hCNcbMtp6kkg",
-            "ref": "7337327e-fc76-4740-a6a4-d82a5fbc2081",
-            "label": "Choice 13"
-          }
-        ]
-      },
-      "validations": {
-        "required": true,
-        "min_selection": 4,
-        "max_selection": 4
-      },
-      "type": "multiple_choice"
-    },
-    {
-      "id": "o0cye0lMrUcW",
-      "title": "What are your preferred selections if you can pick more than one?",
-      "ref": "select-dropdown-typeform",
-      "properties": {
-        "description": "Select Dropdown",
-        "randomize": false,
-        "alphabetical_order": false,
-        "choices": [
-          {
-            "id": "Ug3yOICPvQBU",
-            "ref": "8427e552-fc77-487a-95f7-0dabdad378c3",
-            "label": "Choice 1"
-          },
-          {
-            "id": "c3cifMeDkCkg",
-            "ref": "60d3d3fb-c506-48bb-893f-c49be2ae4564",
-            "label": "Choice 2"
-          },
-          {
-            "id": "osAGXR5RrTNH",
-            "ref": "542f48ca-0e13-4b3e-98f2-dc6a733df5ca",
-            "label": "Choice 3"
-          },
-          {
-            "id": "Z9vVm9N855kI",
-            "ref": "5ed9cd92-cd39-4f81-a432-51c8e3f1fa03",
-            "label": "Choice 4"
-          },
-          {
-            "id": "5Q9z0iQMBghE",
-            "ref": "f429a7ba-1152-4685-b2b6-9d48954ccb5d",
-            "label": "Choice 5"
-          },
-          {
-            "id": "DG52NBYaHQLu",
-            "ref": "458b3c14-ff18-4481-9c02-12ab4477e5c1",
-            "label": "Choice 6"
-          },
-          {
-            "id": "zqyKA5EdZ4zz",
-            "ref": "27a93fcc-fd91-47c9-98ee-47725480fb20",
-            "label": "Choice 7"
-          },
-          {
-            "id": "puasbatuPh9P",
-            "ref": "ae94edeb-f4d4-4dbb-9829-a331e8dacc5c",
-            "label": "Choice 8"
-          },
-          {
-            "id": "YmlaMim8DvAN",
-            "ref": "386b0b2a-d9bc-4f2c-a69d-5c7715c0b803",
-            "label": "Choice 9"
-          },
-          {
-            "id": "yZHBEDZhalxp",
-            "ref": "c25c9067-37af-43cf-8293-aa316fa7e077",
-            "label": "Choice 10"
-          },
-          {
-            "id": "yllDa8yH5NWd",
-            "ref": "9b00e50a-fe8a-4b1d-8226-f9a6d9eee3be",
-            "label": "Choice 11"
-          },
-          {
-            "id": "mKFD51AMW8Nc",
-            "ref": "1602e5b9-b1d1-4ad6-a040-fbc2b65f0678",
-            "label": "Choice 12"
-          },
-          {
-            "id": "ZhevX99Crsng",
-            "ref": "01789c8f-9ad1-496d-86c8-40639e4bbc14",
-            "label": "Choice 13"
-          }
-        ]
-      },
-      "validations": {
-        "required": false
-      },
-      "type": "dropdown"
-    },
-    {
-      "id": "uVd9KWczmiqY",
-      "title": "Please input some short text here",
-      "ref": "short-text-typeform",
-      "properties": {
-        "description": "Short Text Input"
-      },
-      "validations": {
-        "required": false
-      },
-      "type": "short_text"
-    },
-    {
-      "id": "gCx4CXfFPddk",
-      "title": "Please input some long text here",
-      "ref": "long-text-typeform",
-      "properties": {
-        "description": "Long Text Input"
-      },
-      "validations": {
-        "required": false
-      },
-      "type": "long_text"
+    ],
+    "logic": [
+        {
+            "type": "field",
+            "ref": "multiple-choice-typeform",
+            "actions": [
+                {
+                    "action": "jump",
+                    "details": {
+                        "to": {
+                            "type": "field",
+                            "value": "select-dropdown-typeform"
+                        }
+                    },
+                    "condition": {
+                        "op": "is_not",
+                        "vars": [
+                            {
+                                "type": "field",
+                                "value": "multiple-choice-typeform"
+                            },
+                            {
+                                "type": "choice",
+                                "value": "7337327e-fc76-4740-a6a4-d82a5fbc2081"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "action": "jump",
+                    "details": {
+                        "to": {
+                            "type": "thankyou",
+                            "value": "default_tys"
+                        }
+                    },
+                    "condition": {
+                        "op": "always",
+                        "vars": []
+                    }
+                }
+            ]
+        },
+        {
+            "type": "field",
+            "ref": "short-text-typeform",
+            "actions": [
+                {
+                    "action": "jump",
+                    "details": {
+                        "to": {
+                            "type": "thankyou",
+                            "value": "thank-you-2-typeform"
+                        }
+                    },
+                    "condition": {
+                        "op": "begins_with",
+                        "vars": [
+                            {
+                                "type": "field",
+                                "value": "short-text-typeform"
+                            },
+                            {
+                                "type": "constant",
+                                "value": "jump"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "action": "jump",
+                    "details": {
+                        "to": {
+                            "type": "field",
+                            "value": "long-text-typeform"
+                        }
+                    },
+                    "condition": {
+                        "op": "always",
+                        "vars": []
+                    }
+                }
+            ]
+        },
+        {
+            "type": "field",
+            "ref": "opinion-scale-no-labels-typeform",
+            "actions": [
+                {
+                    "action": "jump",
+                    "details": {
+                        "to": {
+                            "type": "field",
+                            "value": "single-choice-typeform"
+                        }
+                    },
+                    "condition": {
+                        "op": "and",
+                        "vars": [
+                            {
+                                "op": "greater_equal_than",
+                                "vars": [
+                                    {
+                                        "type": "field",
+                                        "value": "opinion-scale-no-labels-typeform"
+                                    },
+                                    {
+                                        "type": "constant",
+                                        "value": 1
+                                    }
+                                ]
+                            },
+                            {
+                                "op": "lower_equal_than",
+                                "vars": [
+                                    {
+                                        "type": "field",
+                                        "value": "opinion-scale-no-labels-typeform"
+                                    },
+                                    {
+                                        "type": "constant",
+                                        "value": 9
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                },
+                {
+                    "action": "jump",
+                    "details": {
+                        "to": {
+                            "type": "thankyou",
+                            "value": "thank-you-2-typeform"
+                        }
+                    },
+                    "condition": {
+                        "op": "always",
+                        "vars": []
+                    }
+                }
+            ]
+        },
+        {
+            "type": "field",
+            "ref": "number-min-max-typeform",
+            "actions": [
+                {
+                    "action": "jump",
+                    "details": {
+                        "to": {
+                            "type": "thankyou",
+                            "value": "thank-you-2-typeform"
+                        }
+                    },
+                    "condition": {
+                        "op": "or",
+                        "vars": [
+                            {
+                                "op": "equal",
+                                "vars": [
+                                    {
+                                        "type": "field",
+                                        "value": "number-min-max-typeform"
+                                    },
+                                    {
+                                        "type": "constant",
+                                        "value": 0
+                                    }
+                                ]
+                            },
+                            {
+                                "op": "equal",
+                                "vars": [
+                                    {
+                                        "type": "field",
+                                        "value": "number-min-max-typeform"
+                                    },
+                                    {
+                                        "type": "constant",
+                                        "value": 42
+                                    }
+                                ]
+                            },
+                            {
+                                "op": "equal",
+                                "vars": [
+                                    {
+                                        "type": "field",
+                                        "value": "number-min-max-typeform"
+                                    },
+                                    {
+                                        "type": "constant",
+                                        "value": 99
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                },
+                {
+                    "action": "jump",
+                    "details": {
+                        "to": {
+                            "type": "field",
+                            "value": "date-typeform"
+                        }
+                    },
+                    "condition": {
+                        "op": "always",
+                        "vars": []
+                    }
+                }
+            ]
+        },
+        {
+            "type": "field",
+            "ref": "number-typeform",
+            "actions": [
+                {
+                    "action": "jump",
+                    "details": {
+                        "to": {
+                            "type": "thankyou",
+                            "value": "thank-you-2-typeform"
+                        }
+                    },
+                    "condition": {
+                        "op": "or",
+                        "vars": [
+                            {
+                                "op": "equal",
+                                "vars": [
+                                    {
+                                        "type": "field",
+                                        "value": "number-typeform"
+                                    },
+                                    {
+                                        "type": "constant",
+                                        "value": 42
+                                    }
+                                ]
+                            },
+                            {
+                                "op": "equal",
+                                "vars": [
+                                    {
+                                        "type": "field",
+                                        "value": "number-typeform"
+                                    },
+                                    {
+                                        "type": "constant",
+                                        "value": 99
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                },
+                {
+                    "action": "jump",
+                    "details": {
+                        "to": {
+                            "type": "field",
+                            "value": "number-min-max-typeform"
+                        }
+                    },
+                    "condition": {
+                        "op": "equal",
+                        "vars": [
+                            {
+                                "type": "field",
+                                "value": "number-typeform"
+                            },
+                            {
+                                "type": "constant",
+                                "value": 0
+                            }
+                        ]
+                    }
+                },
+                {
+                    "action": "jump",
+                    "details": {
+                        "to": {
+                            "type": "field",
+                            "value": "date-typeform"
+                        }
+                    },
+                    "condition": {
+                        "op": "always",
+                        "vars": []
+                    }
+                }
+            ]
+        },
+        {
+            "type": "field",
+            "ref": "opinion-scale-typeform",
+            "actions": [
+                {
+                    "action": "jump",
+                    "details": {
+                        "to": {
+                            "type": "field",
+                            "value": "single-choice-typeform"
+                        }
+                    },
+                    "condition": {
+                        "op": "and",
+                        "vars": [
+                            {
+                                "op": "greater_equal_than",
+                                "vars": [
+                                    {
+                                        "type": "field",
+                                        "value": "opinion-scale-typeform"
+                                    },
+                                    {
+                                        "type": "constant",
+                                        "value": 1
+                                    }
+                                ]
+                            },
+                            {
+                                "op": "lower_equal_than",
+                                "vars": [
+                                    {
+                                        "type": "field",
+                                        "value": "opinion-scale-typeform"
+                                    },
+                                    {
+                                        "type": "constant",
+                                        "value": 9
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                },
+                {
+                    "action": "jump",
+                    "details": {
+                        "to": {
+                            "type": "field",
+                            "value": "opinion-scale-no-labels-typeform"
+                        }
+                    },
+                    "condition": {
+                        "op": "equal",
+                        "vars": [
+                            {
+                                "type": "field",
+                                "value": "opinion-scale-typeform"
+                            },
+                            {
+                                "type": "constant",
+                                "value": 0
+                            }
+                        ]
+                    }
+                },
+                {
+                    "action": "jump",
+                    "details": {
+                        "to": {
+                            "type": "thankyou",
+                            "value": "thank-you-2-typeform"
+                        }
+                    },
+                    "condition": {
+                        "op": "always",
+                        "vars": []
+                    }
+                }
+            ]
+        },
+        {
+            "type": "field",
+            "ref": "date-typeform",
+            "actions": [
+                {
+                    "action": "jump",
+                    "details": {
+                        "to": {
+                            "type": "thankyou",
+                            "value": "thank-you-2-typeform"
+                        }
+                    },
+                    "condition": {
+                        "op": "on",
+                        "vars": [
+                            {
+                                "type": "field",
+                                "value": "date-typeform"
+                            },
+                            {
+                                "type": "constant",
+                                "value": "2025-01-01"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "action": "jump",
+                    "details": {
+                        "to": {
+                            "type": "field",
+                            "value": "opinion-scale-typeform"
+                        }
+                    },
+                    "condition": {
+                        "op": "always",
+                        "vars": []
+                    }
+                }
+            ]
+        },
+        {
+            "type": "field",
+            "ref": "question-group-yes-no-typeform",
+            "actions": [
+                {
+                    "action": "jump",
+                    "details": {
+                        "to": {
+                            "type": "field",
+                            "value": "yes-no-typeform"
+                        }
+                    },
+                    "condition": {
+                        "op": "is",
+                        "vars": [
+                            {
+                                "type": "field",
+                                "value": "question-group-yes-no-typeform"
+                            },
+                            {
+                                "type": "constant",
+                                "value": false
+                            }
+                        ]
+                    }
+                },
+                {
+                    "action": "jump",
+                    "details": {
+                        "to": {
+                            "type": "field",
+                            "value": "question-group-file-upload-typeform"
+                        }
+                    },
+                    "condition": {
+                        "op": "always",
+                        "vars": []
+                    }
+                }
+            ]
+        },
+        {
+            "type": "field",
+            "ref": "yes-no-typeform",
+            "actions": [
+                {
+                    "action": "jump",
+                    "details": {
+                        "to": {
+                            "type": "field",
+                            "value": "number-typeform"
+                        }
+                    },
+                    "condition": {
+                        "op": "is",
+                        "vars": [
+                            {
+                                "type": "field",
+                                "value": "yes-no-typeform"
+                            },
+                            {
+                                "type": "constant",
+                                "value": true
+                            }
+                        ]
+                    }
+                },
+                {
+                    "action": "jump",
+                    "details": {
+                        "to": {
+                            "type": "field",
+                            "value": "statement-typeform"
+                        }
+                    },
+                    "condition": {
+                        "op": "always",
+                        "vars": []
+                    }
+                }
+            ]
+        },
+        {
+            "type": "field",
+            "ref": "statement-typeform",
+            "actions": [
+                {
+                    "action": "jump",
+                    "details": {
+                        "to": {
+                            "type": "thankyou",
+                            "value": "thank-you-2-typeform"
+                        }
+                    },
+                    "condition": {
+                        "op": "always",
+                        "vars": []
+                    }
+                }
+            ]
+        },
+        {
+            "type": "field",
+            "ref": "single-choice-typeform",
+            "actions": [
+                {
+                    "action": "jump",
+                    "details": {
+                        "to": {
+                            "type": "field",
+                            "value": "multiple-choice-typeform"
+                        }
+                    },
+                    "condition": {
+                        "op": "always",
+                        "vars": []
+                    }
+                }
+            ]
+        },
+        {
+            "type": "field",
+            "ref": "question-group-file-upload-typeform",
+            "actions": [
+                {
+                    "action": "jump",
+                    "details": {
+                        "to": {
+                            "type": "field",
+                            "value": "yes-no-typeform"
+                        }
+                    },
+                    "condition": {
+                        "op": "always",
+                        "vars": []
+                    }
+                }
+            ]
+        }
+    ],
+    "_links": {
+        "display": "https://tohanuk.typeform.com/to/hu2FodCY",
+        "responses": "https://api.typeform.com/forms/hu2FodCY/responses"
     }
-  ],
-  "logic": [
-    {
-      "type": "field",
-      "ref": "multiple-choice-typeform",
-      "actions": [
-        {
-          "action": "jump",
-          "details": {
-            "to": {
-              "type": "field",
-              "value": "select-dropdown-typeform"
-            }
-          },
-          "condition": {
-            "op": "is_not",
-            "vars": [
-              {
-                "type": "field",
-                "value": "multiple-choice-typeform"
-              },
-              {
-                "type": "choice",
-                "value": "7337327e-fc76-4740-a6a4-d82a5fbc2081"
-              }
-            ]
-          }
-        },
-        {
-          "action": "jump",
-          "details": {
-            "to": {
-              "type": "thankyou",
-              "value": "default_tys"
-            }
-          },
-          "condition": {
-            "op": "always",
-            "vars": []
-          }
-        }
-      ]
-    },
-    {
-      "type": "field",
-      "ref": "short-text-typeform",
-      "actions": [
-        {
-          "action": "jump",
-          "details": {
-            "to": {
-              "type": "thankyou",
-              "value": "thank-you-2-typeform"
-            }
-          },
-          "condition": {
-            "op": "begins_with",
-            "vars": [
-              {
-                "type": "field",
-                "value": "short-text-typeform"
-              },
-              {
-                "type": "constant",
-                "value": "jump"
-              }
-            ]
-          }
-        },
-        {
-          "action": "jump",
-          "details": {
-            "to": {
-              "type": "field",
-              "value": "long-text-typeform"
-            }
-          },
-          "condition": {
-            "op": "always",
-            "vars": []
-          }
-        }
-      ]
-    },
-    {
-      "type": "field",
-      "ref": "opinion-scale-no-labels-typeform",
-      "actions": [
-        {
-          "action": "jump",
-          "details": {
-            "to": {
-              "type": "field",
-              "value": "single-choice-typeform"
-            }
-          },
-          "condition": {
-            "op": "and",
-            "vars": [
-              {
-                "op": "greater_equal_than",
-                "vars": [
-                  {
-                    "type": "field",
-                    "value": "opinion-scale-no-labels-typeform"
-                  },
-                  {
-                    "type": "constant",
-                    "value": 1
-                  }
-                ]
-              },
-              {
-                "op": "lower_equal_than",
-                "vars": [
-                  {
-                    "type": "field",
-                    "value": "opinion-scale-no-labels-typeform"
-                  },
-                  {
-                    "type": "constant",
-                    "value": 9
-                  }
-                ]
-              }
-            ]
-          }
-        },
-        {
-          "action": "jump",
-          "details": {
-            "to": {
-              "type": "thankyou",
-              "value": "thank-you-2-typeform"
-            }
-          },
-          "condition": {
-            "op": "always",
-            "vars": []
-          }
-        }
-      ]
-    },
-    {
-      "type": "field",
-      "ref": "number-min-max-typeform",
-      "actions": [
-        {
-          "action": "jump",
-          "details": {
-            "to": {
-              "type": "thankyou",
-              "value": "thank-you-2-typeform"
-            }
-          },
-          "condition": {
-            "op": "or",
-            "vars": [
-              {
-                "op": "equal",
-                "vars": [
-                  {
-                    "type": "field",
-                    "value": "number-min-max-typeform"
-                  },
-                  {
-                    "type": "constant",
-                    "value": 0
-                  }
-                ]
-              },
-              {
-                "op": "equal",
-                "vars": [
-                  {
-                    "type": "field",
-                    "value": "number-min-max-typeform"
-                  },
-                  {
-                    "type": "constant",
-                    "value": 42
-                  }
-                ]
-              },
-              {
-                "op": "equal",
-                "vars": [
-                  {
-                    "type": "field",
-                    "value": "number-min-max-typeform"
-                  },
-                  {
-                    "type": "constant",
-                    "value": 99
-                  }
-                ]
-              }
-            ]
-          }
-        },
-        {
-          "action": "jump",
-          "details": {
-            "to": {
-              "type": "field",
-              "value": "date-typeform"
-            }
-          },
-          "condition": {
-            "op": "always",
-            "vars": []
-          }
-        }
-      ]
-    },
-    {
-      "type": "field",
-      "ref": "number-typeform",
-      "actions": [
-        {
-          "action": "jump",
-          "details": {
-            "to": {
-              "type": "thankyou",
-              "value": "thank-you-2-typeform"
-            }
-          },
-          "condition": {
-            "op": "or",
-            "vars": [
-              {
-                "op": "equal",
-                "vars": [
-                  {
-                    "type": "field",
-                    "value": "number-typeform"
-                  },
-                  {
-                    "type": "constant",
-                    "value": 42
-                  }
-                ]
-              },
-              {
-                "op": "equal",
-                "vars": [
-                  {
-                    "type": "field",
-                    "value": "number-typeform"
-                  },
-                  {
-                    "type": "constant",
-                    "value": 99
-                  }
-                ]
-              }
-            ]
-          }
-        },
-        {
-          "action": "jump",
-          "details": {
-            "to": {
-              "type": "field",
-              "value": "number-min-max-typeform"
-            }
-          },
-          "condition": {
-            "op": "equal",
-            "vars": [
-              {
-                "type": "field",
-                "value": "number-typeform"
-              },
-              {
-                "type": "constant",
-                "value": 0
-              }
-            ]
-          }
-        },
-        {
-          "action": "jump",
-          "details": {
-            "to": {
-              "type": "field",
-              "value": "date-typeform"
-            }
-          },
-          "condition": {
-            "op": "always",
-            "vars": []
-          }
-        }
-      ]
-    },
-    {
-      "type": "field",
-      "ref": "opinion-scale-typeform",
-      "actions": [
-        {
-          "action": "jump",
-          "details": {
-            "to": {
-              "type": "field",
-              "value": "single-choice-typeform"
-            }
-          },
-          "condition": {
-            "op": "and",
-            "vars": [
-              {
-                "op": "greater_equal_than",
-                "vars": [
-                  {
-                    "type": "field",
-                    "value": "opinion-scale-typeform"
-                  },
-                  {
-                    "type": "constant",
-                    "value": 1
-                  }
-                ]
-              },
-              {
-                "op": "lower_equal_than",
-                "vars": [
-                  {
-                    "type": "field",
-                    "value": "opinion-scale-typeform"
-                  },
-                  {
-                    "type": "constant",
-                    "value": 9
-                  }
-                ]
-              }
-            ]
-          }
-        },
-        {
-          "action": "jump",
-          "details": {
-            "to": {
-              "type": "field",
-              "value": "opinion-scale-no-labels-typeform"
-            }
-          },
-          "condition": {
-            "op": "equal",
-            "vars": [
-              {
-                "type": "field",
-                "value": "opinion-scale-typeform"
-              },
-              {
-                "type": "constant",
-                "value": 0
-              }
-            ]
-          }
-        },
-        {
-          "action": "jump",
-          "details": {
-            "to": {
-              "type": "thankyou",
-              "value": "thank-you-2-typeform"
-            }
-          },
-          "condition": {
-            "op": "always",
-            "vars": []
-          }
-        }
-      ]
-    },
-    {
-      "type": "field",
-      "ref": "date-typeform",
-      "actions": [
-        {
-          "action": "jump",
-          "details": {
-            "to": {
-              "type": "thankyou",
-              "value": "thank-you-2-typeform"
-            }
-          },
-          "condition": {
-            "op": "on",
-            "vars": [
-              {
-                "type": "field",
-                "value": "date-typeform"
-              },
-              {
-                "type": "constant",
-                "value": "2025-01-01"
-              }
-            ]
-          }
-        },
-        {
-          "action": "jump",
-          "details": {
-            "to": {
-              "type": "field",
-              "value": "opinion-scale-typeform"
-            }
-          },
-          "condition": {
-            "op": "always",
-            "vars": []
-          }
-        }
-      ]
-    },
-    {
-      "type": "field",
-      "ref": "group-yes-no-typeform",
-      "actions": [
-        {
-          "action": "jump",
-          "details": {
-            "to": {
-              "type": "field",
-              "value": "yes-no-typeform"
-            }
-          },
-          "condition": {
-            "op": "is",
-            "vars": [
-              {
-                "type": "field",
-                "value": "group-yes-no-typeform"
-              },
-              {
-                "type": "constant",
-                "value": false
-              }
-            ]
-          }
-        },
-        {
-          "action": "jump",
-          "details": {
-            "to": {
-              "type": "field",
-              "value": "number-typeform"
-            }
-          },
-          "condition": {
-            "op": "always",
-            "vars": []
-          }
-        }
-      ]
-    },
-    {
-      "type": "field",
-      "ref": "yes-no-typeform",
-      "actions": [
-        {
-          "action": "jump",
-          "details": {
-            "to": {
-              "type": "thankyou",
-              "value": "thank-you-2-typeform"
-            }
-          },
-          "condition": {
-            "op": "is",
-            "vars": [
-              {
-                "type": "field",
-                "value": "yes-no-typeform"
-              },
-              {
-                "type": "constant",
-                "value": true
-              }
-            ]
-          }
-        },
-        {
-          "action": "jump",
-          "details": {
-            "to": {
-              "type": "field",
-              "value": "statement-typeform"
-            }
-          },
-          "condition": {
-            "op": "always",
-            "vars": []
-          }
-        }
-      ]
-    },
-    {
-      "type": "field",
-      "ref": "statement-typeform",
-      "actions": [
-        {
-          "action": "jump",
-          "details": {
-            "to": {
-              "type": "thankyou",
-              "value": "thank-you-2-typeform"
-            }
-          },
-          "condition": {
-            "op": "always",
-            "vars": []
-          }
-        }
-      ]
-    },
-    {
-      "type": "field",
-      "ref": "single-choice-typeform",
-      "actions": [
-        {
-          "action": "jump",
-          "details": {
-            "to": {
-              "type": "field",
-              "value": "multiple-choice-typeform"
-            }
-          },
-          "condition": {
-            "op": "always",
-            "vars": []
-          }
-        }
-      ]
-    }
-  ],
-  "_links": {
-    "display": "https://tohanuk.typeform.com/to/hu2FodCY",
-    "responses": "https://api.typeform.com/forms/hu2FodCY/responses"
-  }
 }

--- a/typeform/src/commonMain/kotlin/com/typeform/contracts/FieldPropertiesContract.kt
+++ b/typeform/src/commonMain/kotlin/com/typeform/contracts/FieldPropertiesContract.kt
@@ -1,10 +1,12 @@
 package com.typeform.contracts
 
+import com.typeform.models.Upload
 import com.typeform.schema.Choice
 import com.typeform.schema.DateStamp
 import com.typeform.schema.Dropdown
 import com.typeform.schema.FieldProperties
 import com.typeform.schema.FieldType
+import com.typeform.schema.FileUpload
 import com.typeform.schema.Group
 import com.typeform.schema.LongText
 import com.typeform.schema.MultipleChoice
@@ -90,9 +92,17 @@ data class FieldPropertiesContract(
                 FieldProperties.DropdownProperties(
                     Dropdown(
                         choices = choices ?: emptyList(),
+                        description = null,
                         randomize = randomize == true,
                         alphabetical_order = alphabeticalOrder == true,
                     ),
+                )
+            }
+            FieldType.FILE_UPLOAD -> {
+                FieldProperties.FileUploadProperties(
+                    FileUpload(
+                        description = null,
+                    )
                 )
             }
             FieldType.GROUP -> {

--- a/typeform/src/commonMain/kotlin/com/typeform/contracts/FieldPropertiesContract.kt
+++ b/typeform/src/commonMain/kotlin/com/typeform/contracts/FieldPropertiesContract.kt
@@ -1,6 +1,5 @@
 package com.typeform.contracts
 
-import com.typeform.models.Upload
 import com.typeform.schema.Choice
 import com.typeform.schema.DateStamp
 import com.typeform.schema.Dropdown
@@ -102,7 +101,7 @@ data class FieldPropertiesContract(
                 FieldProperties.FileUploadProperties(
                     FileUpload(
                         description = null,
-                    )
+                    ),
                 )
             }
             FieldType.GROUP -> {

--- a/typeform/src/commonMain/kotlin/com/typeform/models/ResponseValue.kt
+++ b/typeform/src/commonMain/kotlin/com/typeform/models/ResponseValue.kt
@@ -16,6 +16,8 @@ sealed class ResponseValue {
 
     data class StringValue(val value: String) : ResponseValue()
 
+    data class UploadValue(val value: Upload) : ResponseValue()
+
     fun asBoolean(): Boolean? {
         return when (this) {
             is BooleanValue -> {
@@ -77,6 +79,17 @@ sealed class ResponseValue {
     fun asString(): String? {
         return when (this) {
             is StringValue -> {
+                this.value
+            }
+            else -> {
+                null
+            }
+        }
+    }
+
+    fun asUpload(): Upload? {
+        return when (this) {
+            is UploadValue -> {
                 this.value
             }
             else -> {

--- a/typeform/src/commonMain/kotlin/com/typeform/models/Responses.kt
+++ b/typeform/src/commonMain/kotlin/com/typeform/models/Responses.kt
@@ -54,6 +54,16 @@ fun Responses.invalidResponseValuesGiven(fields: List<Field>): List<String> {
                         }
                     }
                 }
+                is FieldProperties.FileUploadProperties -> {
+                    when (element.value) {
+                        is ResponseValue.UploadValue -> {
+                            // Expected Type
+                        }
+                        else -> {
+                            ref = element.key
+                        }
+                    }
+                }
                 is FieldProperties.GroupProperties -> {
                     ref = element.key
                 }

--- a/typeform/src/commonMain/kotlin/com/typeform/models/Upload.kt
+++ b/typeform/src/commonMain/kotlin/com/typeform/models/Upload.kt
@@ -1,0 +1,16 @@
+package com.typeform.models
+
+data class Upload(
+    val bytes: ByteArray,
+    val path: Path,
+    val mimeType: String,
+    val fileName: String,
+) {
+    enum class Path(val rawValue: String) {
+        CAMERA("camera"),
+        PHOTO_LIBRARY("photoLibrary"),
+        DOCUMENTS("documents"),
+    }
+
+    companion object
+}

--- a/typeform/src/commonMain/kotlin/com/typeform/schema/Dropdown.kt
+++ b/typeform/src/commonMain/kotlin/com/typeform/schema/Dropdown.kt
@@ -5,6 +5,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class Dropdown(
     val choices: List<Choice>,
+    val description: String?,
     val randomize: Boolean,
     val alphabetical_order: Boolean,
 ) {

--- a/typeform/src/commonMain/kotlin/com/typeform/schema/FieldProperties.kt
+++ b/typeform/src/commonMain/kotlin/com/typeform/schema/FieldProperties.kt
@@ -5,6 +5,8 @@ sealed class FieldProperties {
 
     data class DropdownProperties(val properties: Dropdown) : FieldProperties()
 
+    data class FileUploadProperties(val properties: FileUpload) : FieldProperties()
+
     data class GroupProperties(val properties: Group) : FieldProperties()
 
     data class LongTextProperties(val properties: LongText) : FieldProperties()
@@ -40,6 +42,17 @@ sealed class FieldProperties {
     fun asDropdown(): Dropdown? {
         return when (this) {
             is DropdownProperties -> {
+                this.properties
+            }
+            else -> {
+                null
+            }
+        }
+    }
+
+    fun asFileUpload(): FileUpload? {
+        return when (this) {
+            is FileUploadProperties -> {
                 this.properties
             }
             else -> {
@@ -150,6 +163,12 @@ sealed class FieldProperties {
     val description: String?
         get() = when (this) {
             is DateStampProperties -> {
+                this.properties.description
+            }
+            is DropdownProperties -> {
+                this.properties.description
+            }
+            is FileUploadProperties -> {
                 this.properties.description
             }
             is LongTextProperties -> {

--- a/typeform/src/commonMain/kotlin/com/typeform/schema/FieldType.kt
+++ b/typeform/src/commonMain/kotlin/com/typeform/schema/FieldType.kt
@@ -7,6 +7,7 @@ import kotlinx.serialization.Serializable
 enum class FieldType(val rawValue: String) {
     DATE("date"),
     DROPDOWN("dropdown"),
+    FILE_UPLOAD("file_upload"),
     GROUP("group"),
     LONG_TEXT("long_text"),
     MULTIPLE_CHOICE("multiple_choice"),

--- a/typeform/src/commonMain/kotlin/com/typeform/schema/FileUpload.kt
+++ b/typeform/src/commonMain/kotlin/com/typeform/schema/FileUpload.kt
@@ -1,0 +1,8 @@
+package com.typeform.schema
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class FileUpload(
+    val description: String?,
+)


### PR DESCRIPTION
# Description

Adds initial support for the **file_upload** field type. This type requires each application to configure additional permissions and file providers in the application manifest. The example app shows how these changes should be applied.

Internal Reference: MOB-319

## New/Updated Features

| Question Type | Preview |
| --- | --- |
| ![U1](https://github.com/user-attachments/assets/c14a8176-691b-4251-8d22-f54ff9ac40e4) | ![U3](https://github.com/user-attachments/assets/9ad97a94-d095-4292-97d8-1a92618c1c9f) |
